### PR TITLE
NOISSUE - Enable trailingSlash in Docusaurus config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -9,6 +9,7 @@ const config: Config = {
 
   url: "https://docs.magistrala.absmach.eu",
   baseUrl: "/",
+  trailingSlash: true,
 
   organizationName: "absmach",
   projectName: "magistrala",


### PR DESCRIPTION
# 📚 Documentation Pull Request
This change enables trailing slashes in Docusaurus to ensure:
- consistent canonical URLs
- fewer redirects
- improved SEO and Google Search Console indexing

No content changes.
