### PR TITLE
Add version switcher to docs sidebar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { Rubik } from "next/font/google";
 import { Provider } from "@/components/provider";
+import { VersionSwitcher } from "@/components/version-switcher";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 import "./global.css";
@@ -30,6 +31,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
             tree={source.getPageTree()}
             links={base.links?.filter((item) => item.type === "icon")}
             nav={{ ...base.nav }}
+            sidebar={{ banner: <VersionSwitcher /> }}
           >
             {children}
           </DocsLayout>

--- a/components/version-switcher.tsx
+++ b/components/version-switcher.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Select } from "radix-ui";
+import { CURRENT_VERSION, DOC_VERSIONS } from "@/lib/versions";
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+export function VersionSwitcher() {
+  return (
+    <Select.Root
+      value={CURRENT_VERSION}
+      onValueChange={(value) => {
+        const target = DOC_VERSIONS.find((version) => version.value === value);
+        if (target) window.location.href = target.url;
+      }}
+    >
+      <Select.Trigger
+        aria-label="Select documentation version"
+        className="inline-flex w-full items-center justify-between gap-2 rounded-lg border bg-fd-secondary/50 p-1.5 ps-2 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground"
+      >
+        <Select.Value />
+        <Select.Icon>
+          <ChevronDownIcon />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content
+          position="popper"
+          sideOffset={4}
+          className="z-50 w-(--radix-select-trigger-width) overflow-hidden rounded-lg border bg-fd-popover text-fd-popover-foreground shadow-lg data-[state=closed]:animate-fd-popover-out data-[state=open]:animate-fd-popover-in"
+        >
+          <Select.Viewport className="p-1">
+            {DOC_VERSIONS.map((version) => (
+              <Select.Item
+                key={version.value}
+                value={version.value}
+                className="relative flex cursor-pointer select-none items-center rounded-md py-1.5 ps-7 pe-2 text-sm outline-none data-[highlighted]:bg-fd-accent data-[highlighted]:text-fd-accent-foreground"
+              >
+                <Select.ItemIndicator className="absolute inset-y-0 start-2 inline-flex items-center">
+                  <CheckIcon />
+                </Select.ItemIndicator>
+                <Select.ItemText>{version.label}</Select.ItemText>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+}

--- a/lib/versions.ts
+++ b/lib/versions.ts
@@ -1,0 +1,22 @@
+export interface DocVersion {
+  label: string;
+  value: string;
+  url: string;
+}
+
+// Each version is a fully separate deployment (see README.md).
+// Update this list on every branch when a new version is cut.
+export const DOC_VERSIONS: DocVersion[] = [
+  {
+    label: "Latest",
+    value: "latest",
+    url: "https://absmach.eu/docs/magistrala/",
+  },
+  {
+    label: "v0.30.0",
+    value: "v0.30.0",
+    url: "https://absmach.eu/docs/magistrala/v0-30-0/",
+  },
+];
+
+export const CURRENT_VERSION = "latest";


### PR DESCRIPTION
## Summary
- Companion to the `v0.30.0` branch, which is now deployed as its own versioned app at `/docs/magistrala/v0-30-0/` (see that branch's updated README for the Cloudflare Workers Builds/routing setup).
- Adds a version switcher dropdown to the docs sidebar, rendered directly below the search box.
- Following [Fumadocs' full versioning approach](https://fumadocs.dev/docs/navigation#full-versioning): each version is a fully separate deployment, so the switcher does a real page navigation to the target version's URL rather than client-side routing.
- Version list lives in `lib/versions.ts` — update it here (and on any other active version branch) whenever a new version is cut.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run types:check`
- [x] `pnpm run build`
- [x] Served the static export locally and confirmed the dropdown renders below search, shows "Latest" as active, and lists "v0.30.0" as an option

🤖 Generated with [Claude Code](https://claude.com/claude-code)