### PR TITLE
NOISSUE - Document the new Internal DB (JSON) rule output and JSON writer setup

### DIFF
--- a/content/docs/dev-guide/dev-tools/storage.mdx
+++ b/content/docs/dev-guide/dev-tools/storage.mdx
@@ -174,19 +174,20 @@ By default, the `timescale-writer` add-on's `config.toml` has no `[transformer]`
 A single writer *process* is locked to whichever transformer `format` its `config.toml` specifies - it can't switch between SenML and JSON per message. To store both formats at once, run a **second** `timescale-writer` instance dedicated to JSON, alongside the default SenML one:
 
 1. Copy the `timescale-writer` add-on's compose service (or the `MG_TIMESCALE_WRITER_CONFIG_PATH` config it loads) to a second instance, e.g. `timescale-writer-json`.
-2. Give the new instance a `config.toml` with the JSON transformer:
+2. Give the new instance a `config.toml` with the JSON transformer. The `[subscriber]` section's `topics` key takes slash-delimited MQTT-style filters (`+` for one level, `#` for a variable-length trailing suffix) - the same syntax the writer add-ons already use, for both NATS and FluxMQ builds:
 
    ```toml
    [subscriber]
-   subjects = ["channels.>"]
+   topics = ["writers/+/c/+/json"]
 
    [transformer]
    format = "JSON"
    ```
 
-3. Leave the existing SenML `timescale-writer` instance's `config.toml` and `subjects` filter unchanged.
+   This particular filter matches messages whose subtopic is exactly `json` - the case where the rule's input channel itself has no subtopic, which the Rules Engine's [Internal DB (JSON)](/user-guide/rules-engine#store-as-json) output produces by default. If your rule's input channel does have a subtopic, the JSON output appends `/json` to it instead (e.g. an input subtopic of `devices/dev-1` becomes `devices/dev-1/json`), which needs an extra `+` per subtopic level to match, e.g. `writers/+/c/+/+/json`.
+3. Leave the existing SenML `timescale-writer` instance's `config.toml` and `topics` filter unchanged (it defaults to `["writers/#"]`, matching every writer-bound message regardless of format).
 
-Note that NATS's multi-level wildcard (`>`) can only match a variable-length *suffix* of a subject, not messages whose subtopic ends in a particular segment regardless of depth - there's no single subject filter that means "anything ending in `.../json`". If you want the JSON writer to only ever see JSON-tagged traffic, scope `subjects` to the specific channel(s)/subtopic prefixes you expect it on instead of the catch-all above. With the catch-all, the JSON writer simply attempts to parse every message it receives as JSON: messages whose subtopic doesn't end in a `json` segment still get stored, just under a table named after whatever their own last subtopic segment is, rather than the `json` table - harmless clutter, not data corruption, but worth scoping down for tidiness once you know your deployment's topic structure.
+`#` is a trailing wildcard only - it can't express "anything ending in `.../json`" regardless of depth in a single filter, so a topic tree with subtopics of varying depth needs either one `+`-based filter per depth you expect, or falling back to the broader `["writers/#"]` catch-all. With that catch-all, the JSON writer attempts to parse every message it receives as JSON: messages whose subtopic doesn't end in a `json` segment still get stored, just under a table named after whatever their own last subtopic segment is, rather than the `json` table - harmless clutter, not data corruption, but worth scoping down with the `+`-based filter above once you know your deployment's topic structure.
 
 As explained above, the JSON transformer derives its destination table from the last segment of the message's subtopic - so messages published (or, from a rule, saved) with a subtopic ending in `json` land in a table literally named `json`, matching what a channel's [Message Views](/user-guide/message-views) JSON-format view queries for.
 

--- a/content/docs/dev-guide/dev-tools/storage.mdx
+++ b/content/docs/dev-guide/dev-tools/storage.mdx
@@ -167,6 +167,29 @@ docker-compose -f docker/addons/timescale-writer/docker-compose.yml up -d
 
 Timescale default port (5432) is exposed, so you can use various tools for database inspection and data visualization.
 
+By default, the `timescale-writer` add-on's `config.toml` has no `[transformer]` section at all, which means it silently falls back to the SenML transformer (see [Transformer config](#transformer-config) above) - it will not persist JSON messages, including ones saved via the Rules Engine's [Internal DB (JSON)](/user-guide/rules-engine#store-as-json) output.
+
+#### Running SenML and JSON Writers Together
+
+A single writer *process* is locked to whichever transformer `format` its `config.toml` specifies - it can't switch between SenML and JSON per message. To store both formats at once, run a **second** `timescale-writer` instance dedicated to JSON, alongside the default SenML one:
+
+1. Copy the `timescale-writer` add-on's compose service (or the `MG_TIMESCALE_WRITER_CONFIG_PATH` config it loads) to a second instance, e.g. `timescale-writer-json`.
+2. Give the new instance a `config.toml` with the JSON transformer:
+
+   ```toml
+   [subscriber]
+   subjects = ["channels.>"]
+
+   [transformer]
+   format = "JSON"
+   ```
+
+3. Leave the existing SenML `timescale-writer` instance's `config.toml` and `subjects` filter unchanged.
+
+Note that NATS's multi-level wildcard (`>`) can only match a variable-length *suffix* of a subject, not messages whose subtopic ends in a particular segment regardless of depth - there's no single subject filter that means "anything ending in `.../json`". If you want the JSON writer to only ever see JSON-tagged traffic, scope `subjects` to the specific channel(s)/subtopic prefixes you expect it on instead of the catch-all above. With the catch-all, the JSON writer simply attempts to parse every message it receives as JSON: messages whose subtopic doesn't end in a `json` segment still get stored, just under a table named after whatever their own last subtopic segment is, rather than the `json` table - harmless clutter, not data corruption, but worth scoping down for tidiness once you know your deployment's topic structure.
+
+As explained above, the JSON transformer derives its destination table from the last segment of the message's subtopic - so messages published (or, from a rule, saved) with a subtopic ending in `json` land in a table literally named `json`, matching what a channel's [Message Views](/user-guide/message-views) JSON-format view queries for.
+
 ## Readers
 
 Readers provide an implementation of various `message readers`. Message readers are services that consume normalized (in `SenML` format) Magistrala messages from data storage and opens HTTP API for message consumption. Installing corresponding writer before reader is implied.

--- a/content/docs/dev-guide/services/rules-engine.mdx
+++ b/content/docs/dev-guide/services/rules-engine.mdx
@@ -21,7 +21,7 @@ The **Rules Engine** in Magistrala provides powerful, flexible message processin
 
 1. **Scriptable logic** - Use Lua or Go to define message execution behavior.
 2. **Flexible execution** - Rules can be triggered from input messages, schedules or both.
-3. **Pluggable outputs** - Built-in support for alarms, channels, email, Postgres, and SenML writers.
+3. **Pluggable outputs** - Built-in support for alarms, channels, email, Postgres, and SenML/JSON internal-DB writers.
 4. **Secure, scoped execution** - Using domain-level isolation and bearer token authorization. See the [Roles Schema](/dev-guide/roles-schema) for details on available roles and permissions.
 5. **Disabled rules** - Rules can be disabled individually to prevent further executions. They can also be enabled to re-start their executions.
 
@@ -222,7 +222,7 @@ The script should return a value if it triggers an action. Otherwise, it should 
 
 ### Supported Message Formats
 
-The Rules Engine supports multiple message formats, but when **storing messages to the internal database**, the payload **must be in SenML format**.  
+The Rules Engine supports multiple message formats. When **storing messages to the internal database**, you choose the output that matches your payload: the **save_senml** output requires the payload to be a valid SenML message (see below), while the **save_json** output accepts any JSON-marshalable value with no format validation.  
 Valid SenML Example:
 
 ```json
@@ -278,11 +278,12 @@ These may break internal parsing or rule pattern matching.
 The **outputs** field allows a rule to define **multiple destinations** or **actions** for its result. Supported output types include:
 
 1. **channels**: Publishes the result to a specific channel/topic.
-2. **save_senml**: Stores messages in Magistrala’s internal database.
-3. **save_remote_pg**: Forwards the result to an external PostgreSQL database.
-4. **alarms**: Triggers an alarm with a structured severity report.
-5. **email**: Sends a notification email.
-6. **Slack**: Sends a slack notification.
+2. **save_senml**: Stores messages in Magistrala’s internal database as SenML.
+3. **save_json**: Stores messages in Magistrala’s internal database as raw JSON, with no SenML validation.
+4. **save_remote_pg**: Forwards the result to an external PostgreSQL database.
+5. **alarms**: Triggers an alarm with a structured severity report.
+6. **email**: Sends a notification email.
+7. **Slack**: Sends a slack notification.
 
 #### channels
 
@@ -301,6 +302,16 @@ type SenML struct {
   Type    string  `json:"type"`
 }
 ```
+
+#### save_json
+
+```go
+type JSON struct {
+  Type    string  `json:"type"`
+}
+```
+
+Unlike `save_senml`, this output does not validate the logic's result as SenML - any JSON-marshalable value is stored as-is. The message's stored `subtopic` is suffixed with `json` so it lands in a table by that name, matching what a [Message View](/user-guide/message-views) in JSON format queries for. It requires a JSON-capable writer to be deployed - see [Running SenML and JSON Writers Together](/dev-guide/dev-tools/storage#running-senml-and-json-writers-together).
 
 #### save_remote_pg
 
@@ -348,7 +359,7 @@ type Slack struct {
 ```
 
 Each output type expects a different data structure depending on its destination.
-For example, if your output is save_senml, it expects the result of the logic to be a valid SenML message.
+For example, if your output is save_senml, it expects the result of the logic to be a valid SenML message; if your output is save_json instead, any JSON-marshalable result is accepted.
 e.g.
 
 ```lua

--- a/content/docs/dev-guide/storage-architecture.mdx
+++ b/content/docs/dev-guide/storage-architecture.mdx
@@ -197,6 +197,8 @@ LIMIT 100;
 
 TimescaleDB's planner first uses chunk pruning to narrow the scan to the relevant time chunks, then applies the attribute filters against the hypertable's indexes. Message rows reference entities by identifier (`channel`, `publisher`) rather than by foreign key — the time-series store and the identity store (Atom's PostgreSQL) are deliberately separate services. Mapping those identifiers back to human-readable metadata (client names, tenant, location) is resolved at the application layer through Atom, keeping the high-write message path decoupled from the control plane.
 
+The fixed `messages` hypertable above is SenML-only. Arbitrary JSON payloads don't fit that flat, typed schema, so `timescale-writer` stores them differently: instead of one shared table, it creates a table on demand for each distinct message *format* (a name derived from the message's subtopic, not a fixed schema), with a single `payload JSONB` column holding the whole object. See [Running SenML and JSON Writers Together](/dev-guide/dev-tools/storage#running-senml-and-json-writers-together) for how this is configured and deployed.
+
 ---
 
 ## Authorization

--- a/content/docs/user-guide/rules-engine/overview.mdx
+++ b/content/docs/user-guide/rules-engine/overview.mdx
@@ -341,7 +341,7 @@ Store message processing results to your PostgreSQL database. Select the Postgre
 
 #### Internal DB
 
-To be able to store messages in the internal Magistrala DB, you need to create a rule that processes the results. More information about this is in the [Store Messages](#store-messages) section.
+To be able to store messages in the internal Magistrala DB, you need to create a rule that processes the results. There are two Internal DB output nodes: one that stores the result as **SenML**, and one that stores it as raw **JSON**. More information about both is in the [Store Messages](#store-messages) section.
 
 ![Magistrala DB rule example](../../img/rules/internal-db-rule.png)
 
@@ -445,9 +445,11 @@ This helps automate rule execution based on custom schedules.
 
 ## Store Messages
 
-To store messages in Magistrala's internal database, you must create a **Rule** for this.
+To store messages in Magistrala's internal database, you must create a **Rule** for this. The Rules Engine has two output nodes for this: **Internal DB** (SenML) and **Internal DB (JSON)**.
 
-- Magistrala only stores messages in [**SenML** format](https://datatracker.ietf.org/doc/html/rfc8428#section-4.3).
+### Store as SenML
+
+- The **Internal DB** output node stores messages in [**SenML** format](https://datatracker.ietf.org/doc/html/rfc8428#section-4.3).
 - You can submit data in any format(e.g, JSON), but must convert it to SenML using a Lua script.
   SenML format fields:
 
@@ -541,6 +543,27 @@ return logicFunction()
 ```
 
 ![Storage with senml input](../../img/rules/rule.png)
+
+### Store as JSON
+
+If you don't want to convert your payload to SenML, use the **Internal DB (JSON)** output node instead. It stores whatever your logic script returns as raw JSON, with no format validation — return the message payload directly, or any JSON-marshalable value your script builds:
+
+```lua title="Lua script"
+function logicFunction()
+  return message.payload
+end
+return logicFunction()
+```
+
+Add an **Internal DB (JSON)** output node to the rule the same way you would an **Internal DB** (SenML) node — the two are independent and a rule can use both at once if you want the same result saved in both formats.
+
+Messages saved this way show up in the channel's [Message Views](/user-guide/message-views) as JSON-format views.
+
+:::info
+
+A JSON-capable message writer must be deployed for these messages to actually persist — see [Running SenML and JSON Writers Together](/dev-guide/dev-tools/storage#running-senml-and-json-writers-together). Without it, the rule will run successfully but the message won't be saved.
+
+:::
 
 :::info
 


### PR DESCRIPTION
## Summary
- Documents the Rules Engine's new `save_json` output (alongside the existing `save_senml`) across the user and dev guides. Backing implementation: [absmach/magistrala-ee#9](https://github.com/absmach/magistrala-ee/pull/9).
- Fills a gap in the existing storage docs: they described the writer's SenML/JSON transformer toggle generically but never confirmed whether TimescaleDB specifically supports the JSON path, or explained how to run both formats at once (a single writer process is locked to one static transformer format).
- `user-guide/rules-engine/overview.mdx` - splits "Store Messages" into SenML and JSON paths, adds a JSON example, and links to the writer deployment requirement.
- `dev-guide/services/rules-engine.mdx` - adds `save_json` to the output type reference alongside `save_senml`.
- `dev-guide/dev-tools/storage.mdx` - new "Running SenML and JSON Writers Together" section: deploying a second, JSON-configured `timescale-writer` instance, a config example, and the NATS subject-matching caveat that makes exact "ends in json" topic filtering impossible (worth calling out explicitly rather than giving a misleading example).
- `dev-guide/storage-architecture.mdx` - notes that the SenML-only `messages` hypertable isn't where JSON payloads land; JSON uses a per-format table created on demand instead.
- Companion to [absmach/magistrala-docs#165](https://github.com/absmach/magistrala-docs/pull/165) (Message Views), which this PR is cross-linked with but doesn't depend on or modify.

## Test plan
- [x] `pnpm run types:check` (fumadocs-mdx + next typegen + tsc) passes
- [x] `pnpm run build` - full production build succeeds, all 181 pages generate
- [x] `pnpm run lint` passes