### PR TITLE
NOISSUE - Close Enterprise Edition gaps and fix stale build/CLI instructions

### DIFF
--- a/content/docs/dev-guide/architecture.mdx
+++ b/content/docs/dev-guide/architecture.mdx
@@ -4,6 +4,15 @@ title: Architecture
 
 ## Components
 
+<Callout type="error" title="Table below needs maintainer verification">
+  Magistrala went through an identity/authorization migration to Atom shortly before this page was
+  last reviewed. As a result, `users`, `groups`, `clients`, `channels`, and `domains` no longer
+  exist as top-level packages in the [magistrala repository](https://github.com/absmach/magistrala)
+  — their current canonical location could not be confirmed (the repository they previously lived
+  in, SuperMQ, has since been archived). The links below are left as-is for reference but are
+  likely broken; please confirm the current locations before treating this table as accurate.
+</Callout>
+
 Magistrala IoT platform is comprised of the following services:
 
 | Service                          | Description                                                                                   |
@@ -19,7 +28,7 @@ Magistrala IoT platform is comprised of the following services:
 | [consumers][consumers]           | Receives messages and persists or forwards them to configured destinations                    |
 | [provision][provision]           | Provides an HTTP API for automated provisioning of clients and channels                       |
 | [readers][readers]               | Implements message readers for PostgreSQL and TimescaleDB                                     |
-| [rules-engine][rules-engine]     | Creates rules using Lua scripts that process incoming messages                                |
+| rules-engine (Enterprise Edition)| Creates rules using Lua scripts that process incoming messages — see [Rules Engine][ee-rules-engine] |
 
 ![arch](../img/architecture.svg)
 
@@ -64,7 +73,7 @@ Running Magistrala on gateway moves computation from cloud towards the edge thus
 [consumers]: https://github.com/absmach/magistrala/tree/main/consumers
 [provision]: https://github.com/absmach/magistrala/tree/main/provision
 [readers]: https://github.com/absmach/magistrala/tree/main/readers
-[rules-engine]: https://github.com/absmach/magistrala/tree/main/re
+[ee-rules-engine]: /dev-guide/services/rules-engine
 [nats]: https://nats.io/
 [rabbitmq]: https://www.rabbitmq.com/
 [vernemq]: https://vernemq.com/

--- a/content/docs/dev-guide/authorization.mdx
+++ b/content/docs/dev-guide/authorization.mdx
@@ -179,6 +179,13 @@ A `platform` is the highest-level entity that manages multiple organizations.
 
 Each Magistrala service maps its API operations to SpiceDB permissions via `docker/permission.yaml`, loaded at startup. The **Scope** column indicates whether the check runs against the **domain** entity (broad, domain-wide access) or the **specific entity** (fine-grained, object-level access).
 
+<Callout type="warn" title="Enterprise Edition">
+  The `rule`, `alarm`, and `report` entities below are managed by services that are part of
+  Magistrala Enterprise Edition (EE) — their source code is not included in this open-source
+  repository. The SpiceDB relations/permissions themselves are still defined in this repository's
+  schema, since they are shared infrastructure loaded by the EE service images at deploy time.
+</Callout>
+
 ### Rules
 
 A `rule` defines the conditions that trigger alarms. Rules support role management and can grant fine-grained alarm lifecycle permissions per rule.

--- a/content/docs/dev-guide/cli/clients-cli.mdx
+++ b/content/docs/dev-guide/cli/clients-cli.mdx
@@ -13,6 +13,13 @@ keywords:
 image: /img/mg-preview.png
 ---
 
+<Callout type="warn" title="Source verification needed">
+  These commands are not currently present in the `magistrala/cli` package (they were removed as
+  part of the Atom identity migration). They may still be accurate if provided by another CLI
+  composed elsewhere — see the note on the [CLI introduction](/dev-guide/cli/introduction-to-cli)
+  page.
+</Callout>
+
 Magistrala CLI provides a simple and efficient way to manage clients or devices. Below are the key commands to create, connect, assign and manage clients within your system.
 
 ### Create Client

--- a/content/docs/dev-guide/cli/domains-cli.mdx
+++ b/content/docs/dev-guide/cli/domains-cli.mdx
@@ -13,6 +13,13 @@ keywords:
 image: /img/mg-preview.png
 ---
 
+<Callout type="warn" title="Source verification needed">
+  These commands are not currently present in the `magistrala/cli` package (they were removed as
+  part of the Atom identity migration). They may still be accurate if provided by another CLI
+  composed elsewhere — see the note on the [CLI introduction](/dev-guide/cli/introduction-to-cli)
+  page.
+</Callout>
+
 
 Magistrala CLI provides a simple and efficient way to manage domains. Below are the key commands to manage domains within your system.
 

--- a/content/docs/dev-guide/cli/groups-cli.mdx
+++ b/content/docs/dev-guide/cli/groups-cli.mdx
@@ -13,6 +13,13 @@ keywords:
 image: /img/mg-preview.png
 ---
 
+<Callout type="warn" title="Source verification needed">
+  These commands are not currently present in the `magistrala/cli` package (they were removed as
+  part of the Atom identity migration). They may still be accurate if provided by another CLI
+  composed elsewhere — see the note on the [CLI introduction](/dev-guide/cli/introduction-to-cli)
+  page.
+</Callout>
+
 
 Magistrala CLI provides an efficient way to manage groups within your system. This guide covers the key commands for **creating**, **retrieving**, **updating**, and **managing groups**.
 

--- a/content/docs/dev-guide/cli/introduction-to-cli.mdx
+++ b/content/docs/dev-guide/cli/introduction-to-cli.mdx
@@ -26,9 +26,17 @@ The latest Magistrala release is published on the Magistrala releases page:
 
 Recent Magistrala releases do not consistently publish `magistrala-cli` binaries under the release assets. If you need the CLI locally, use one of the installation methods below.
 
-### Option 2 — Build from Source
+### Option 2 — Build from Source (unverified)
 
-Alternatively, **magistrala-cli** can be built directly from source.
+<Callout type="error" title="Build instructions need maintainer verification">
+  The Magistrala repository no longer contains a `cmd/cli` entry point or a `make cli` target —
+  `cli/` is now a command library only (`bootstrap`, `certs`, `channels`, `consumers`,
+  `invitations`, `health`, `message`, `provision`), with no `main` package wiring it into a
+  binary. The previous composition point was the SuperMQ repository, but that repository has
+  since been archived. As of this writing there is no confirmed, buildable source for the
+  `magistrala-cli` binary. Please confirm the current build/distribution path before publishing
+  this section.
+</Callout>
 
 1. Clone the Magistrala repository.
 
@@ -51,20 +59,20 @@ Alternatively, **magistrala-cli** can be built directly from source.
   sudo cp ./build/cli /usr/local/bin/mg
   ```
 
-> *Tip:* Running `make cli` automatically checks for an existing binary and rebuilds only if necessary.
+> **Note:** `cli` is not currently part of the Makefile's service list, so `make cli` is expected to fail until the build is restored.
 
-### **Option 3 — Run via Docker**
+### Option 3 — Run via Docker (unverified)
 
-The CLI can also be executed through the official **`magistrala/cli`** Docker image:
+The CLI has previously been distributed as a Docker image:
 
 ```bash
-docker run -it --rm magistrala/cli -u http://<SERVER_URL> [command]
+docker run -it --rm ghcr.io/absmach/magistrala/cli:latest -u http://<SERVER_URL> [command]
 ```
 
 **For Example:**
 
 ```bash
-docker run -it --rm magistrala/cli -u http://192.168.160.1 users token admin@example.com 12345678
+docker run -it --rm ghcr.io/absmach/magistrala/cli:latest -u http://192.168.160.1 users token admin@example.com 12345678
 ```
 
 The response should be:
@@ -79,7 +87,7 @@ The response should be:
 This allows direct interaction with Magistrala services without installing the binary locally.
 
 **Example:**  
-Run `magistrala/cli` and connect it to a running Magistrala instance using the `-u` flag to specify the server URL.  
+Run the `cli` image and connect it to a running Magistrala instance using the `-u` flag to specify the server URL.  
 The CLI will return authentication tokens or perform other operations as requested.
 
 ## Usage
@@ -221,10 +229,10 @@ For "users" service, the response should look like this:
 When Magistrala is updated, a new Docker image of **`magistrala-cli`** is also published.  
 Developers can update the CLI by either:
 
-- Pulling the latest Docker image (`magistrala/cli:latest`), or
+- Pulling the latest Docker image (`ghcr.io/absmach/magistrala/cli:latest`), or
 
 ```bash
-docker pull magistrala/cli:latest
+docker pull ghcr.io/absmach/magistrala/cli:latest
 ```
 
 - Downloading the newest binary from the [**Magistrala releases page**][releases].

--- a/content/docs/dev-guide/cli/meta.json
+++ b/content/docs/dev-guide/cli/meta.json
@@ -9,7 +9,7 @@
     "clients-cli",
     "messages-cli",
     "provision-cli",
-    "boostrap-cli",
+    "bootstrap-cli",
     "consumers-cli"
   ]
 }

--- a/content/docs/dev-guide/cli/users-cli.mdx
+++ b/content/docs/dev-guide/cli/users-cli.mdx
@@ -13,6 +13,13 @@ image: /img/mg-preview.png
 
 ---
 
+<Callout type="warn" title="Source verification needed">
+  These commands are not currently present in the `magistrala/cli` package (they were removed as
+  part of the Atom identity migration). They may still be accurate if provided by another CLI
+  composed elsewhere — see the note on the [CLI introduction](/dev-guide/cli/introduction-to-cli)
+  page.
+</Callout>
+
 
 Magistrala CLI provides a simple and efficient way to manage users. Below are the key commands to create, authenticate, and manage users within your system.
 

--- a/content/docs/dev-guide/getting-started.mdx
+++ b/content/docs/dev-guide/getting-started.mdx
@@ -103,18 +103,23 @@ Individual microservices can be built with:
 make <microservice_name>
 ```
 
+`<microservice_name>` must be one of the names in the Makefile's `SERVICES` list — currently
+`atom-bootstrap`, `certs`, `postgres-writer`, `postgres-reader`, `timescale-writer`,
+`timescale-reader`, and `fluxmq`. Services outside this list (e.g. `auth`, which still has a
+`cmd/auth` entry point) can be built directly with `go build -o build/<name> cmd/<name>/main.go`.
+
 For example:
 
 ```bash
-make bootstrap
+make atom-bootstrap
 ```
 
-will build the Bootstrap microservice.
+will build the Atom Bootstrap microservice.
 
 The response will be:
 
 ```bash
-CGO_ENABLED=0 GOOS= GOARCH=amd64 GOARM= go build -tags nats --tags nats -ldflags "-s -w -X 'github.com/absmach/magistrala.BuildTime=2025-02-11_14:54:15' -X 'github.com/absmach/magistrala.Version=unknown' -X 'github.com/absmach/magistrala.Commit=ddc43c482f6c98f3a4d49aa1d609bfae9e0e7d34'" -o build/bootstrap cmd/bootstrap/main.go
+CGO_ENABLED=0 GOOS= GOARCH=amd64 GOARM= go build -tags nats --tags nats -ldflags "-s -w -X 'github.com/absmach/magistrala.BuildTime=2025-02-11_14:54:15' -X 'github.com/absmach/magistrala.Version=unknown' -X 'github.com/absmach/magistrala.Commit=ddc43c482f6c98f3a4d49aa1d609bfae9e0e7d34'" -o build/atom-bootstrap cmd/atom-bootstrap/main.go
 ```
 
 #### Build Dockers
@@ -134,7 +139,7 @@ make docker_<microservice_name>
 For example:
 
 ```bash
-make docker_bootstrap
+make docker_atom-bootstrap
 ```
 
 > N.B. Magistrala creates `FROM scratch` docker containers which are compact and small in size.
@@ -540,65 +545,22 @@ With Magistrala installed and running, you can now explore its messaging capabil
 
 ## SpiceDB Schema Management
 
-Magistrala's authorization is powered by [SpiceDB](https://authzed.com/spicedb). The schema is split across two source files and merged into a single deployable schema:
+Magistrala's authorization is powered by [SpiceDB](https://authzed.com/spicedb). Unlike [SuperMQ](https://github.com/absmach/supermq) — which Magistrala builds on and which splits its schema into an override/combined pair fetched and merged via `scripts/combine-schema.sh` — Magistrala ships a single, directly-edited schema file:
 
 | File | Purpose |
 |---|---|
-| `docker/spicedb/override-schema.zed` | Magistrala extensions (alarm, rule, report definitions + domain/team injections) — edit this file to extend the schema |
-| `docker/spicedb/combined-schema.zed` | Generated output — the schema actually loaded into SpiceDB at runtime |
+| `docker/spicedb/schema.zed` | The full schema loaded into SpiceDB at runtime, including Magistrala's entity, relation, and permission definitions (e.g. `alarm`, `rule`, `report`) |
 
-> **Never edit `combined-schema.zed` directly.** It is auto-generated and will be overwritten on the next combine run.
-
-The `docker/spicedb/` directory intentionally contains only `override-schema.zed` and `combined-schema.zed`. Any stale `schema.zed` that appears there (e.g. after a manual copy) is automatically removed by the combine script.
-
-### Fetching the Latest Magistrala Schema
-
-When Magistrala publishes upstream schema changes, pull them and regenerate the combined schema with:
-
-```bash
-make fetch_magistrala
-```
-
-This runs `scripts/magistrala.sh`, which:
-
-1. Clones the Magistrala repository (sparse checkout, `docker/` folder only).
-2. Replaces `docker/magistrala-docker/` with the freshly fetched files.
-3. Automatically runs `scripts/combine-schema.sh` to regenerate `combined-schema.zed`.
-
-### How the Combine Script Works
-
-`scripts/combine-schema.sh` merges the two schemas by injecting Magistrala's extensions directly into the upstream Magistrala schema:
-
-1. **Extract the `domain` overlay block** from `override-schema.zed` — reads Magistrala-specific relations (e.g. `alarm_update`, `rule_create`), domain-level permissions (e.g. `alarm_read_permission`), and the `membership_extension` expression.
-2. **Extract the `team` overlay block** — same process, relations only.
-3. **Inject into the upstream Magistrala schema** — Magistrala relations and permissions are inserted after the last Magistrala group relation/permission; `membership_extension` is spliced into `permission membership` before `organization->admin`.
-4. **Append remaining definitions** — the overlay `domain`/`team` blocks are stripped (already merged); everything else (`definition alarm`, `definition rule`, `definition report`, etc.) is appended verbatim.
-5. **Write output** to `docker/spicedb/combined-schema.zed` with a generated-file header.
-6. **Clean up** — any stale `docker/spicedb/schema.zed` is removed.
+There is no fetch step and no generated/combined file for this schema — edit `docker/spicedb/schema.zed` directly.
 
 ### Adding a New Entity to the Schema
 
 To extend the schema with a new Magistrala entity (for example `dashboard`):
 
-1. In `override-schema.zed`, add the new relations and permissions to the overlay `definition domain` block (e.g. `dashboard_read`, `dashboard_read_permission`).
-2. Update `permission membership_extension` in the overlay domain block to include the new relations.
-3. Mirror the new relations in the overlay `definition team` block.
-4. Add the entity definition (`definition dashboard { ... }`) below the team block in `override-schema.zed`.
-5. Regenerate:
-
-```bash
-sh scripts/combine-schema.sh
-```
-
-6. Update `docker/permission.yaml` with the new entity's operation-to-permission mappings.
-
-### Regenerating Without Fetching
-
-If you only changed `override-schema.zed` and don't need a Magistrala update:
-
-```bash
-sh scripts/combine-schema.sh
-```
+1. Add the new relations and permissions to `definition domain` in `docker/spicedb/schema.zed` (e.g. `dashboard_read`, `dashboard_read_permission`).
+2. Add the entity definition (`definition dashboard { ... }`) alongside the other entity definitions in the same file.
+3. Update `docker/permission.yaml` with the new entity's operation-to-permission mappings.
+4. Restart the SpiceDB container (or redeploy) to pick up the schema change.
 
 [docker]: https://docs.docker.com/install/
 [docker-compose]: https://docs.docker.com/compose/install/

--- a/content/docs/dev-guide/services/auth.mdx
+++ b/content/docs/dev-guide/services/auth.mdx
@@ -73,11 +73,14 @@ PATs allow API access without primary credentials. They are scoped to specific e
 
 Auth is distributed as a Docker container. It requires a running PostgreSQL instance, SpiceDB, and (optionally) Redis for PAT caching.
 
+> **Note:** `auth` is not currently in the Makefile's `SERVICES` list, so `make auth` will fail
+> with "No rule to make target". Build it directly with `go build` instead, as shown below.
+
 ```bash
 git clone https://github.com/absmach/magistrala
 cd magistrala
 
-make auth
+go build -o build/auth cmd/auth/main.go
 make install
 
 MG_AUTH_LOG_LEVEL=info \

--- a/content/docs/dev-guide/services/channels.mdx
+++ b/content/docs/dev-guide/services/channels.mdx
@@ -12,6 +12,14 @@ keywords:
 image: /img/mg-preview.png
 ---
 
+<Callout type="warn" title="Source location needs maintainer verification">
+  There is no `cmd/channels` entry point in the current Magistrala repository, so the `make channels`
+  command shown below will not work as-is. This service's code appears to have moved as part of
+  Magistrala's identity/authorization migration to Atom (see the note on the
+  [Architecture](/dev-guide/architecture) page) — its current canonical source location
+  could not be confirmed.
+</Callout>
+
 The **Channels service** manages communication channels in Magistrala. A channel is a message topic that clients connect to for pub/sub messaging. The service handles channel creation, configuration, client connections, group hierarchy, and role-based access control. It exposes both HTTP and gRPC APIs.
 
 ## Configuration

--- a/content/docs/dev-guide/services/clients.mdx
+++ b/content/docs/dev-guide/services/clients.mdx
@@ -12,6 +12,14 @@ keywords:
 image: /img/mg-preview.png
 ---
 
+<Callout type="warn" title="Source location needs maintainer verification">
+  There is no `cmd/clients` entry point in the current Magistrala repository, so the `make clients`
+  command shown below will not work as-is. This service's code appears to have moved as part of
+  Magistrala's identity/authorization migration to Atom (see the note on the
+  [Architecture](/dev-guide/architecture) page) — its current canonical source location
+  could not be confirmed.
+</Callout>
+
 The **Clients service** manages the devices and applications that connect to Magistrala. A client represents any entity that publishes or subscribes to messages. The service handles client provisioning, credential management, channel connections, and role-based access control. It exposes both HTTP and gRPC APIs.
 
 ## Configuration

--- a/content/docs/dev-guide/services/journal.mdx
+++ b/content/docs/dev-guide/services/journal.mdx
@@ -9,6 +9,7 @@ keywords:
   - Observability
   - Magistrala
 image: /img/mg-preview.png
+enterprise: true
 ---
 
 The **Journal service** consumes the platform event stream from NATS, persists each event to PostgreSQL, and exposes HTTP endpoints for querying the audit log and viewing per-client telemetry (first/last seen, message in/out counters, active subscriptions). It is the primary observability tool for tracking what happened and when across the platform.

--- a/content/docs/dev-guide/services/notifications.mdx
+++ b/content/docs/dev-guide/services/notifications.mdx
@@ -10,6 +10,7 @@ keywords:
   - Events
   - Magistrala
 image: /img/mg-preview.png
+enterprise: true
 ---
 
 The **Notifications service** is an event-driven service that sends email notifications for domain invitation lifecycle events. It listens to the platform event stream (NATS or RabbitMQ), fetches user details from the Users service over gRPC, and delivers styled HTML emails via SMTP when a user is invited to a domain, accepts an invitation, or rejects one.

--- a/content/docs/dev-guide/services/users.mdx
+++ b/content/docs/dev-guide/services/users.mdx
@@ -12,6 +12,14 @@ keywords:
 image: /img/mg-preview.png
 ---
 
+<Callout type="warn" title="Source location needs maintainer verification">
+  There is no `cmd/users` entry point in the current Magistrala repository, so the `make users`
+  command shown below will not work as-is. This service's code appears to have moved as part of
+  Magistrala's identity/authorization migration to Atom (see the note on the
+  [Architecture](/dev-guide/architecture) page) — its current canonical source location
+  could not be confirmed.
+</Callout>
+
 The **Users service** provides an HTTP API for managing user accounts on the Magistrala platform. It handles registration, login, profile updates, password reset, email verification, and account lifecycle (enable/disable/delete). It communicates with the Auth service over gRPC for token issuance and validation.
 
 ## Configuration

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -37,8 +37,9 @@ It accepts user and client connections over various network protocols (i.e. HTTP
 - Extensibility and customization support.
 - Mutual TLS Authentication (mTLS).
 - Message Persistance.
-- Rules Engine.
-- Alarms and Triggers.
+- Rules Engine (Enterprise Edition).
+- Alarms and Triggers (Enterprise Edition).
+- Reports (Enterprise Edition).
 - Event Sourcing.
 - Edge and IoT ready.
 - Developer Tools with comprehensive SDK and CLI.

--- a/content/docs/user-guide/clients-management/channels.mdx
+++ b/content/docs/user-guide/clients-management/channels.mdx
@@ -236,6 +236,11 @@ For detailed instructions on each protocol, see the [Messaging Guide](/dev-guide
 
 ### Saving Messages
 
+<Callout type="warn" title="Enterprise Edition">
+  Message persistence via Rules is provided by the Rules Engine service, which is part of
+  Magistrala Enterprise Edition (EE). This workflow requires EE to be deployed.
+</Callout>
+
 For a message to be saved on the Magistrala database, a **Rule** must be created in Rules Engine in relation to the specific channel and topic. This has been further discussed in the [**Rules Engine** documentation](/user-guide/rules-engine).
 
 The messages table will then update to include the message sent with the latest message appearing first.

--- a/content/docs/user-guide/clients-management/clients.mdx
+++ b/content/docs/user-guide/clients-management/clients.mdx
@@ -169,6 +169,11 @@ Clicking on the **Assign Member** button will open a dialog box that allows the 
 
 ## Client Alarms
 
+<Callout type="warn" title="Enterprise Edition">
+  This section requires the Alarms service, which is part of Magistrala Enterprise Edition (EE).
+  See the [Alarms documentation](/user-guide/alarms) for details.
+</Callout>
+
 The **Alarms** section displays all alarms triggered by this specific client. This provides a focused view of alerts related to the client's activity and helps with targeted troubleshooting.
 
 From this page, you can perform all standard alarm management actions:

--- a/content/docs/user-guide/dashboards/alarmcount.mdx
+++ b/content/docs/user-guide/dashboards/alarmcount.mdx
@@ -8,6 +8,7 @@ keywords:
   - Alert Count
   - System Monitoring
 image: /img/mg-preview.png
+enterprise: true
 ---
 
 The **Alarm Count** widget displays the total number of alarms based on your filter criteria. It provides a quick overview of system alerts in a compact card format.

--- a/content/docs/user-guide/dashboards/alarmtable.mdx
+++ b/content/docs/user-guide/dashboards/alarmtable.mdx
@@ -8,6 +8,7 @@ keywords:
   - Alert Management
   - System Monitoring
 image: /img/mg-preview.png
+enterprise: true
 ---
 
 The **Alarm Table** widget displays detailed alarm information in a structured table format. It provides comprehensive visibility into system alerts with customizable columns and filtering options.

--- a/content/docs/user-guide/dashboards/widgets.mdx
+++ b/content/docs/user-guide/dashboards/widgets.mdx
@@ -38,7 +38,7 @@ Magistrala offers a variety of widgets, including charts, data cards, gauges, ma
   - Route Map
   - Marker Map
   - Polygon Map
-- **Alarms**:
+- **Alarms** (Enterprise Edition):
   - Alarm Table
   - Alarm Count
 - **Facility**:

--- a/content/docs/user-guide/domain-management/domain.mdx
+++ b/content/docs/user-guide/domain-management/domain.mdx
@@ -66,6 +66,11 @@ This section helps you quickly access or create dashboards without navigating aw
 
 ### Alarms Overview
 
+<Callout type="warn" title="Enterprise Edition">
+  This section requires the Alarms service, which is part of Magistrala Enterprise Edition (EE).
+  See the [Alarms documentation](/user-guide/alarms) for details.
+</Callout>
+
 The **Alarms Overview** section summarizes active and historical alarms within the domain.  
 It highlights alarms that are currently active, assigned or acknowledged, helping administrators quickly identify and manage system events that require attention.
 

--- a/content/docs/user-guide/users-quick-start.mdx
+++ b/content/docs/user-guide/users-quick-start.mdx
@@ -192,6 +192,11 @@ Clients can be connected to channels in groups. This is done in the **Connection
 
 ## Create a Rule
 
+<Callout type="warn" title="Enterprise Edition">
+  Rules Engine is part of Magistrala Enterprise Edition (EE). This step requires EE to be
+  deployed — see the [Rules Engine documentation](/user-guide/rules-engine) for details.
+</Callout>
+
 To store any messages in the Magistrala database, you must first create and save a **Rule** using **Rules Engine**.
 
 Navigate to the **Rules Engine** section on the navigation bar and click on `+ Create`.


### PR DESCRIPTION
## What does this do?

Closes two gaps in the Community/Enterprise edition split:

1. **Missing `enterprise: true` flags.** Journal and Notifications moved to Magistrala EE alongside
   Alarms, Reports, and Rules Engine (absmach/magistrala#3552), but only the latter three were
   flagged in the edition split (#163) — likely because that PR landed a few days before the EE
   move. Added the flag to `journal.mdx`, `notifications.mdx`, and the two alarm dashboard widgets
   (`alarmcount.mdx`, `alarmtable.mdx`). Verified via `npm run build`: all four now appear only in
   the Enterprise output, not the Community output.
2. **Un-gated pages that reference EE-only functionality.** Pages like `architecture.mdx`,
   `authorization.mdx`, domain/client management, `channels.mdx`, `users-quick-start.mdx`,
   `widgets.mdx`, and the index landing page aren't EE-specific themselves, so they can't be
   gated — but they silently assumed EE features (Alarms, Rules Engine) are always present. Added
   inline Enterprise Edition callouts at each of those points instead.

Also fixes instructions that no longer match the current `magistrala` repo, found while doing the
above:

- `getting-started.mdx`'s "SpiceDB Schema Management" section described tooling
  (`override-schema.zed`, `combine-schema.sh`, `make fetch_magistrala`) that doesn't exist in that
  repo — replaced with the actual single-`schema.zed` workflow.
- `make <service>` instructions for services no longer in the Makefile's `SERVICES` list (`auth`,
  `channels`, `clients`, `users`, `bootstrap`) — corrected where a working alternative exists, or
  flagged for maintainer confirmation where the service's source location is unclear post-Atom
  migration.
- CLI install instructions no longer assert an unverified build/release path now that SuperMQ (the
  CLI's binary composition point) has been archived — flagged instead of asserting a guess, and
  remaining `magistrala/cli` Docker Hub references corrected to `ghcr.io/absmach/magistrala/cli`.
- Dead `re/` repo link in `architecture.mdx`, and a `cli/meta.json` typo (`boostrap-cli` ->
  `bootstrap-cli`).

## Have you included tests for your changes?

No traditional tests, but verified with `npm run build` (both editions): the four newly-gated
pages appear in the Enterprise output (181 pages) and are absent from the Community output (127
pages), and the full build has no MDX/type errors.

## Notes

Several of the "needs maintainer verification" callouts point at a broader, currently-unresolved
question: after the Atom identity migration and the SuperMQ archive, it's unclear where
`users`/`clients`/`channels`/`domains`/`groups` service code and the `magistrala-cli` build now
live. Filed as absmach/magistrala#3563 to track separately — this PR only makes the docs honest
about that uncertainty rather than guessing.
