### PR TITLE
Latest docs: add v0.51.0 to the version switcher

### DIFF
--- a/lib/versions.ts
+++ b/lib/versions.ts
@@ -13,6 +13,11 @@ export const DOC_VERSIONS: DocVersion[] = [
     url: "https://absmach.eu/docs/magistrala/",
   },
   {
+    label: "v0.51.0",
+    value: "v0.51.0",
+    url: "https://absmach.eu/docs/magistrala/v0-51-0/",
+  },
+  {
     label: "v0.30.0",
     value: "v0.30.0",
     url: "https://absmach.eu/docs/magistrala/v0-30-0/",


### PR DESCRIPTION
## Summary
- Adds the `v0.51.0` entry to `lib/versions.ts`'s `DOC_VERSIONS` list so it's discoverable from Latest's version selector, alongside `v0.30.0`.

Small, standalone, no dependency on the other Latest overhaul PRs — safe to merge first.

## Context
Part of the Latest docs overhaul. `v0.51.0` itself is a separately frozen historical snapshot (its own branch/deployment, not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)