### PR TITLE
Latest docs: user-guide overhaul (dashboards, rules engine, messaging, alarms, reports, Bootstrap, and more)

### DIFF
--- a/content/docs/user-guide/alarms.mdx
+++ b/content/docs/user-guide/alarms.mdx
@@ -21,9 +21,9 @@ The alarm object includes the following fields:
 | ----------------- | --------------------------------------------------------- | -------------------- |
 | `id`              | Unique identifier of the alarm                            | ❌                   |
 | `rule_id`         | ID of the rule that triggered the alarm                   | ✅ (added by system) |
-| `domain_id`       | ID of the domain this alarm belongs to                    | ✅ (added by system) |
+| `workspace_id`    | ID of the workspace this alarm belongs to                 | ✅ (added by system) |
 | `channel_id`      | ID of the channel related to the alarm                    | ✅ (added by system) |
-| `client_id`       | ID of the client associated with the alarm                | ✅ (added by system) |
+| `client_id`       | ID of the Device associated with the alarm (API field name is still `client_id`) | ✅ (added by system) |
 | `subtopic`        | Subtopic of the message that triggered the alarm          | ❌                   |
 | `status`          | Current status of the alarm (e.g., active, cleared)       | ❌                   |
 | `measurement`     | Name of the measurement involved in the alarm condition   | ✅                   |
@@ -304,7 +304,7 @@ To clear an alarm:
 
 ## Assign Alarm
 
-To assign an alarm to a domain member:
+To assign an alarm to a workspace member:
 
 1. Click the quick links button next to the alarm
 2. Select **Assign** from the dropdown menu

--- a/content/docs/user-guide/bootstrap.mdx
+++ b/content/docs/user-guide/bootstrap.mdx
@@ -1,0 +1,51 @@
+---
+title: Bootstrap
+description: Configure devices to auto-connect securely from the UI
+keywords:
+  - Bootstrap
+  - Device provisioning
+  - Bootstrap Profile
+  - External ID
+  - External key
+image: /img/mg-preview.png
+---
+
+## Overview
+
+Bootstrap lets a device fetch its own runtime configuration on first boot (or whenever it needs to recover), instead of having that configuration baked in or entered by hand. A device that only has bootstrap credentials — an **External ID** and **External key** — can call the Bootstrap service and receive back the configuration it needs to start talking to Magistrala.
+
+Bootstrap is separate from creating Devices and Channels directly: those are provisioned as usual through [Device Management](/user-guide/device-management), and Bootstrap stores its own enrollment record referencing them.
+
+Bootstrap appears in the sidebar under **Device Management**, alongside Devices, Gateways, and Device Types, at `/workspace/{workspaceId}/bootstraps`.
+
+## Bootstrap Profiles
+
+A **Profile** is a reusable template that says how a device's configuration should be rendered — you write it once and reuse it across every device of that type (e.g. "Raspberry Pi temperature sensor").
+
+To create one, go to **Bootstrap → Profiles** and click **Create**:
+
+- **Name** (required)
+- **Description** (optional)
+- **Template Format** — the format the rendered configuration is produced in
+- **Content Template** — the template body itself
+- **Binding Slots** — named placeholders the template needs filled in before it can render (each slot has a name, a resource type such as `client`, and whether it's required)
+
+A slot doesn't create anything by itself — it declares what a Bootstrap Config binding to this profile still needs to attach (e.g. a specific Channel for telemetry) before that device's configuration can render.
+
+## Bootstrap Configs
+
+A **Config** is the actual per-device enrollment record. To create one, go to **Bootstrap → Configs** and click **Create**:
+
+- **Name** (required)
+- **External ID** (required) — the identifier the device itself will present when it calls Bootstrap
+- **External Key** (required) — the credential the device presents alongside its External ID; Bootstrap only stores it hashed
+- **Profile** (optional) — attach a Profile if you want this device's configuration rendered from a template
+- **Client Cert / Client Key / CA Cert** (optional, legacy) — only needed for the older certificate-based bootstrap flow
+
+Once created, opening a Config shows its status and lets you bind the resources its Profile's slots ask for (a Channel for a `telemetry` slot, for example). Binding copies a snapshot of that resource into the Config, so the device's own bootstrap call never has to reach Devices or Channels directly — it renders entirely from what's already stored on the Config, its Profile, and those snapshots.
+
+## How a device bootstraps
+
+A device that only has its External ID and External key calls the Bootstrap service with those credentials. Bootstrap looks up the matching Config, renders it (using its Profile and binding snapshots, if any), and returns the rendered configuration to the device — the device now has what it needs to connect and doesn't need to be given a Client ID/secret by hand.
+
+For the full data model (Config/Profile/Binding slot/Binding snapshot) and the service-level API, see [the Bootstrap dev-guide page](/dev-guide/services/bootstrap).

--- a/content/docs/user-guide/dashboards/controls.mdx
+++ b/content/docs/user-guide/dashboards/controls.mdx
@@ -189,7 +189,7 @@ After editing, the slider values can be adjusted in defined **steps** (e.g., inc
 
 #### Conclusion
 
-**Control Cards** enable direct, real-time control over IoT devices within a domain. Whether toggling a relay or adjusting a value, they provide a seamless, intuitive interface.
+**Control Cards** enable direct, real-time control over IoT devices within a workspace. Whether toggling a relay or adjusting a value, they provide a seamless, intuitive interface.
 
 Key highlights:
 

--- a/content/docs/user-guide/dashboards/countcard.mdx
+++ b/content/docs/user-guide/dashboards/countcard.mdx
@@ -11,7 +11,7 @@ image: /img/mg-preview.png
 ---
 
 
-A **Count Card** provides a quick overview of the total number of entities such as devices, channels, members, or groups within a domain. It offers a snapshot of how many entities are available, based on the selected entity type and status.
+A **Count Card** provides a quick overview of the total number of entities such as devices, channels, members, or groups within a workspace. It offers a snapshot of how many entities are available, based on the selected entity type and status.
 
 ### Create a Count Card
 
@@ -74,4 +74,4 @@ Count Cards are versatile and can be customized to meet specific needs. Customiz
 
 #### **Conclusion**
 
-With Count Cards, users can effectively monitor the total number of devices, channels, members, or groups in their domain. These cards are ideal for quickly assessing critical metrics at a glance.
+With Count Cards, users can effectively monitor the total number of devices, channels, members, or groups in their workspace. These cards are ideal for quickly assessing critical metrics at a glance.

--- a/content/docs/user-guide/dashboards/dashboards.mdx
+++ b/content/docs/user-guide/dashboards/dashboards.mdx
@@ -17,7 +17,7 @@ image: /img/mg-preview.png
 
 ### Create a New Dashboard
 
-After logging into a **Domain**, navigate to the **Dashboards** tab and click the `Create` button.
+After logging into a **Workspace**, navigate to the **Dashboards** tab and click the `Create` button.
 
 A dialog will appear prompting you to configure the new dashboard. At the top of the dialog is a **type switch** that lets you choose between creating a **Dashboard** or a **Template**.
 
@@ -135,17 +135,17 @@ The dashboard is private and visible only to you.
 
 ![Private Dashboard](../../img/dashboards/dashboard-private.png)
 
-#### Domain Members
+#### Workspace Members
 
-The dashboard is accessible to all members of your domain.
+The dashboard is accessible to all members of your workspace.
 
-![Domain Members Share Option](../../img/dashboards/share-option-domain.png)
+![Workspace Members Share Option](../../img/dashboards/share-option-workspace.png)
 
-![Domain Members Dashboard](../../img/dashboards/dashboard-domain.png)
+![Workspace Members Dashboard](../../img/dashboards/dashboard-workspace.png)
 
 #### Selected Users
 
-Only specific domain members you choose can access the dashboard. Select one or more users from the domain member list to grant access.
+Only specific workspace members you choose can access the dashboard. Select one or more users from the workspace member list to grant access.
 
 ![Selected Users Share Option](../../img/dashboards/share-selected-dialog.png)
 

--- a/content/docs/user-guide/dashboards/introduction.mdx
+++ b/content/docs/user-guide/dashboards/introduction.mdx
@@ -21,13 +21,13 @@ Magistrala offers two types of dashboards:
 
 ### Dashboards
 
-A **dashboard** connects directly to specific data sources in your domain. You configure each widget with explicit data sources, making it ideal for personal or team-level views of known devices and data streams.
+A **dashboard** connects directly to specific data sources in your workspace. You configure each widget with explicit data sources, making it ideal for personal or team-level views of known devices and data streams.
 
 For instructions on creating, editing, sharing, and managing dashboards, see the [Dashboard Guide](/user-guide/dashboards/dashboards).
 
 ### Templates
 
-A **template** is a dashboard with abstract data sources. Instead of selecting specific entities, each widget is configured using **tags**. When a domain member views a template that has been shared with them, the system automatically resolves each tag to the entity assigned to that user — so the same template can display different data for different users, all within the same layout.
+A **template** is a dashboard with abstract data sources. Instead of selecting specific entities, each widget is configured using **tags**. When a workspace member views a template that has been shared with them, the system automatically resolves each tag to the entity assigned to that user — so the same template can display different data for different users, all within the same layout.
 
 Templates are particularly useful for multi-user deployments, such as:
 
@@ -35,4 +35,4 @@ Templates are particularly useful for multi-user deployments, such as:
 - **Field technician views** — each technician sees readings from the equipment assigned to them, using a single shared template.
 - **Facility or zone monitoring** — users assigned to a specific floor or area see data from the entities tagged for their location.
 
-> Templates can only be created by **domain admins**. For full details on creating, configuring, and sharing templates, see the [Templates Guide](/user-guide/dashboards/templates).
+> Templates can only be created by **workspace admins**. For full details on creating, configuring, and sharing templates, see the [Templates Guide](/user-guide/dashboards/templates).

--- a/content/docs/user-guide/dashboards/tablecard.mdx
+++ b/content/docs/user-guide/dashboards/tablecard.mdx
@@ -5,12 +5,12 @@ keywords:
   - Entity list
   - Device overview
   - IoT dashboard table
-  - Domain management
+  - Workspace management
   - Pagination widget
 image: /img/mg-preview.png
 ---
 
-**Table Cards** are powerful widgets for displaying lists of entities—such as clients (devices), members, groups, or channels—within a domain. They present key information like entity names, statuses, and creation dates, and include built-in pagination for easy navigation through large datasets.
+**Table Cards** are powerful widgets for displaying lists of entities—such as clients (devices), members, groups, or channels—within a workspace. They present key information like entity names, statuses, and creation dates, and include built-in pagination for easy navigation through large datasets.
 
 ### Create a Table Card
 
@@ -22,7 +22,7 @@ Click the `Add Widget` button and select **Table Card** from the list of availab
 1. **Entity Type**: Select the type of entity to display in the table. The available options are:
    - **Client** (device)
    - **Channel**
-   - **Member** (the users assigned to the currently logged in domain)
+   - **Member** (the users assigned to the currently logged in workspace)
    - **Group**
 
 2. **Entity Status**: Select whether to display:
@@ -62,7 +62,7 @@ Once changes are made, click the `Update` button. The widget will refresh to ref
 
 #### Customizing Table Cards
 
-- **Entity Types**: Table Cards can display a variety of entity types, giving users a centralized view of different components within their domain.
+- **Entity Types**: Table Cards can display a variety of entity types, giving users a centralized view of different components within their workspace.
 
 - **Tags**: Applying tags enables users to filter large datasets based on custom labels—useful for grouping devices or team members by location, role, or purpose.
 
@@ -70,4 +70,4 @@ Once changes are made, click the `Update` button. The widget will refresh to ref
 
 #### Conclusion
 
-Table Cards provide a versatile and organized way for users to monitor entities within a domain. Whether tracking the status of connected devices, managing members, or reviewing groups, this widget offers a customizable and performant table view, complete with refresh intervals and filtering tools for improved usability.
+Table Cards provide a versatile and organized way for users to monitor entities within a workspace. Whether tracking the status of connected devices, managing members, or reviewing groups, this widget offers a customizable and performant table view, complete with refresh intervals and filtering tools for improved usability.

--- a/content/docs/user-guide/dashboards/templates.mdx
+++ b/content/docs/user-guide/dashboards/templates.mdx
@@ -7,14 +7,14 @@ keywords:
   - Tag-based Dashboards
   - IoT Customer Portal
   - Multi-user Dashboards
-  - Domain Admin
+  - Workspace Admin
   - Abstract Data Sources
 image: /img/mg-preview.png
 ---
 
 ### What are Templates?
 
-Templates are dashboards with **abstract data sources**. Instead of binding each widget to a specific channel or client, you configure widgets using **tags**. When a domain member views a shared template, the system resolves each tag to the entity assigned to that user — so the same template layout serves multiple users, each seeing their own data.
+Templates are dashboards with **abstract data sources**. Instead of binding each widget to a specific channel or client, you configure widgets using **tags**. When a workspace member views a shared template, the system resolves each tag to the entity assigned to that user — so the same template layout serves multiple users, each seeing their own data.
 
 
 This makes templates ideal for any scenario where many users need an identical dashboard layout but with data from their own assigned devices.
@@ -23,7 +23,7 @@ This makes templates ideal for any scenario where many users need an identical d
 
 #### Customer Portals
 
-Enterprise customers often need a self-service view of their own equipment and data. With templates, a domain admin creates a single dashboard layout once. Each customer is then assigned the entities (clients, channels) tagged appropriately, and when they log in they see a fully populated dashboard with their data — without any additional setup.
+Enterprise customers often need a self-service view of their own equipment and data. With templates, a workspace admin creates a single dashboard layout once. Each customer is then assigned the entities (clients, channels) tagged appropriately, and when they log in they see a fully populated dashboard with their data — without any additional setup.
 
 > Magistrala provides **custom customer portals** for enterprise users built on top of this templates feature. Contact us to learn more.
 
@@ -40,27 +40,27 @@ For deployments across multiple floors, buildings, or geographic zones, you can 
 
 ### How Tag Resolution Works
 
-When a domain member opens a shared template, the system resolves data sources for each widget as follows:
+When a workspace member opens a shared template, the system resolves data sources for each widget as follows:
 
 1. The widget is configured with a **tag** (e.g., `temperature-sensor`).
 2. The system looks up entities (clients, channels) assigned to the viewing user that carry that tag.
 3. The matching entity is used as the data source for that widget.
 
-> **Important:** Each user should have **at most one entity of a given type** with a particular tag. If multiple entities match, the system uses the **first entity** returned in the list. The domain admin is responsible for ensuring tags are applied correctly and unambiguously.
+> **Important:** Each user should have **at most one entity of a given type** with a particular tag. If multiple entities match, the system uses the **first entity** returned in the list. The workspace admin is responsible for ensuring tags are applied correctly and unambiguously.
 
 ### Prerequisites
 
-Before sharing a template, the domain admin must ensure:
+Before sharing a template, the workspace admin must ensure:
 
-- The relevant entities (clients, channels) have the correct tags applied.
-- Those entities are **assigned to the appropriate users** in the domain.
+- The relevant entities (devices, channels) have the correct tags applied.
+- Those entities are **assigned to the appropriate users** in the workspace.
 - Each user has **only one entity per type** with any given tag used in the template.
 
-> See the [Members Guide](/user-guide/domain-management/domain#domain-members) for instructions on assigning entities to users.
+> See the [Members Guide](/user-guide/workspace-management/workspace#workspace-members) for instructions on assigning entities to users.
 
 ### Creating a Template
 
-Only **domain admins** can create templates.
+Only **workspace admins** can create templates.
 
 Navigate to the **Dashboards** tab and click `+ Create`. In the create dialog, use the **type switch** at the top to select **Template** instead of Dashboard.
 
@@ -92,10 +92,10 @@ The tag you enter must match a tag on the entity assigned to each user who will 
 
 ### Sharing a Template
 
-A template must be shared with domain members for them to see it when they view the domain. The same share options available for dashboards apply to templates:
+A template must be shared with workspace members for them to see it when they view the workspace. The same share options available for dashboards apply to templates:
 
 - **None** — visible only to you (the admin who created it)
-- **Domain Members** — all domain members can view the template with their own data
+- **Workspace Members** — all workspace members can view the template with their own data
 - **Selected Users** — only the users you choose can view the template
 
 To update the share state, click the `Share` icon on the template card and select the desired option.

--- a/content/docs/user-guide/message-views.mdx
+++ b/content/docs/user-guide/message-views.mdx
@@ -29,7 +29,7 @@ Either way, a JSON-format view also needs a JSON-capable message writer deployed
 
 ## Accessing views
 
-Views appear on both the domain-wide **Messages** page (`/messages`, with a channel selector) and on an individual channel's own **Messages** tab. Either way, you'll see a row of tabs above the table: **All Messages** (the default, unfiltered view) followed by any saved views, and a **+** button to create a new one.
+Views appear on both the workspace-wide **Messages** page (`/messages`, with a channel selector) and on an individual channel's own **Messages** tab. Either way, you'll see a row of tabs above the table: **All Messages** (the default, unfiltered view) followed by any saved views, and a **+** button to create a new one.
 
 ![Messages page with three view tabs: All Messages, Diagnostics, and Temperature Readings](../img/message-views/all-messages-tab.png)
 

--- a/content/docs/user-guide/messaging.mdx
+++ b/content/docs/user-guide/messaging.mdx
@@ -76,7 +76,7 @@ You can copy these commands to your terminal and execute them. The messages sent
 To publish message over channel with a client, the command should be in the format:
 
 ```bash
-curl -s -S -i --cacert /etc/ssl/certs/ca-certificates.crt -X POST -H "Content-Type: application/senml+json" -H "Authorization: Client <client_secret>" https://messaging.magistrala.absmach.eu/http/m/<domain_id>/c/<channel_id> -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+curl -s -S -i --cacert /etc/ssl/certs/ca-certificates.crt -X POST -H "Content-Type: application/senml+json" -H "Authorization: Client <device_secret>" https://messaging.magistrala.absmach.eu/http/m/<workspace_id>/c/<channel_id> -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 Note that if you're going to use SenML message format, you should always send messages as an array.
@@ -90,16 +90,16 @@ To send and receive messages over MQTT you could use [Mosquitto tools][mosquitto
 To publish message over channel, client should call following command:
 
 ```bash
-mosquitto_pub -I <client_name> -u <client_id> -P <client_secret> -t m/<domain_id>/c/<channel_id> -h messaging.magistrala.absmach.eu -m '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+mosquitto_pub -I <device_name> -u <device_id> -P <device_secret> -t m/<workspace_id>/c/<channel_id> -h messaging.magistrala.absmach.eu -m '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 To subscribe to channel, client should call following command:
 
 ```bash
-mosquitto_sub -I <client_name> -u <client_id> -P <client_secret> -t m/<domain_id>/c/<channel_id> -h messaging.magistrala.absmach.eu
+mosquitto_sub -I <device_name> -u <device_id> -P <device_secret> -t m/<workspace_id>/c/<channel_id> -h messaging.magistrala.absmach.eu
 ```
 
-If you want to use standard topic such as `m/<domain_id>/c/<channel_id>` with SenML content type (JSON or CBOR), you should use following topic `m/<domain_id>/c/<channel_id>`.
+If you want to use standard topic such as `m/<workspace_id>/c/<channel_id>` with SenML content type (JSON or CBOR), you should use following topic `m/<workspace_id>/c/<channel_id>`.
 
 If you are using TLS to secure MQTT connection, add `--cafile docker/ssl/certs/ca.crt`
 to every command.
@@ -113,31 +113,31 @@ Examples:
 To subscribe to a topic:
 
 ```bash
-coap-cli get m/<domain_id>c/<channel_id>/subtopic -auth <client_secret> -o -h messaging.magistrala.absmach.eu -p 5684 -s
+coap-cli get m/<workspace_id>c/<channel_id>/subtopic -auth <device_secret> -o -h messaging.magistrala.absmach.eu -p 5684 -s
 ```
 
 To send a message to a channel with a topic:
 
 ```bash
-coap-cli post m/<domain_id>c/<channel_id>/subtopic -auth <client_secret> -d "hello world" -h messaging.magistrala.absmach.eu -p 5684 -s
+coap-cli post m/<workspace_id>c/<channel_id>/subtopic -auth <device_secret> -d "hello world" -h messaging.magistrala.absmach.eu -p 5684 -s
 ```
 
 To send a message, use `POST` request. To subscribe, send `GET` request with Observe option (flag `o`) set to false.
 
 ## WebSocket
 
-To publish and receive messages over channel using web socket, you should first send handshake request to `/m/<domain_id>/c/<channel_id>` path. Don't forget to send `Authorization` header with client authorization token. In order to pass message content type to WS adapter you can use `Content-Type` header.
+To publish and receive messages over channel using web socket, you should first send handshake request to `/m/<workspace_id>/c/<channel_id>` path. Don't forget to send `Authorization` header with client authorization token. In order to pass message content type to WS adapter you can use `Content-Type` header.
 
 To connect and subscribe to a channel using WS the client shoudl use the command:
 
 ```bash
-wscat -c "wss://messaging.magistrala.absmach.eu/api/ws/m/<domain_id>/c/<channel_id>/<subtopic>/?authorization=<client_secret"
+wscat -c "wss://messaging.magistrala.absmach.eu/api/ws/m/<workspace_id>/c/<channel_id>/<subtopic>/?authorization=<device_secret"
 ```
 
 To send a message to a channel with a topic, use:
 
 ```bash
-wscat -c "wss://messaging.magistrala.absmach.eu/api/ws/m/<domain_id>/c/<channel_id>/<subtopic>/?authorization=<client_secret" -x '[{"n":"voltage","bu":"V","u":"V","bt":1761838262251000000,"v":350}]'
+wscat -c "wss://messaging.magistrala.absmach.eu/api/ws/m/<workspace_id>/c/<channel_id>/<subtopic>/?authorization=<device_secret" -x '[{"n":"voltage","bu":"V","u":"V","bt":1761838262251000000,"v":350}]'
 ```
 
 ## MQTT-over-WS
@@ -174,8 +174,8 @@ Here is an example of a browser application connecting to Magistrala server and 
     }
 
     var channelId = '08676a76-101d-439c-b62e-d4bb3b014337'
-    var domainId = '6a45444c-4c89-46f9-a284-9e731674726a'
-    var topic = 'm/' + domainId + '/c/' + channelId
+    var workspaceId = '6a45444c-4c89-46f9-a284-9e731674726a'
+    var topic = 'm/' + workspaceId + '/c/' + channelId
 
     // Connect string, and specify the connection method by the protocol
     // ws Unencrypted WebSocket connection
@@ -219,15 +219,15 @@ client.connect({ onSuccess: onConnect });
 
 ## Subtopics
 
-In order to use subtopics and give more meaning to your pub/sub channel, you can simply add any suffix to base `/m/<domain_id>/c/<channel_id>` topic.
+In order to use subtopics and give more meaning to your pub/sub channel, you can simply add any suffix to base `/m/<workspace_id>/c/<channel_id>` topic.
 
-Example subtopic publish/subscribe for bedroom temperature would be `m/<domain_id>/c/<channel_id>/bedroom/temperature`.
+Example subtopic publish/subscribe for bedroom temperature would be `m/<workspace_id>/c/<channel_id>/bedroom/temperature`.
 
 Subtopics are generic and multilevel. You can use almost any suffix with any depth.
 
 Topics with subtopics are propagated to Message broker in the following format `channels.<channel_id>.<optional_subtopic>`.
 
-Our example topic `m/<domain_id>/c/<channel_id>/bedroom/temperature` will be translated to appropriate Message Broker topic `channels.<channel_id>.bedroom.temperature`.
+Our example topic `m/<workspace_id>/c/<channel_id>/bedroom/temperature` will be translated to appropriate Message Broker topic `channels.<channel_id>.bedroom.temperature`.
 
 You can use multilevel subtopics, that have multiple parts. These parts are separated by `.` or `/` separators.
 When you use combination of these two, have in mind that behind the scene, `/` separator will be replaced with `.`.

--- a/content/docs/user-guide/meta.json
+++ b/content/docs/user-guide/meta.json
@@ -7,6 +7,7 @@
     "device-management",
     "gateway-management",
     "device-types",
+    "bootstrap",
     "dashboards",
     "rules-engine",
     "messaging",

--- a/content/docs/user-guide/metadata.mdx
+++ b/content/docs/user-guide/metadata.mdx
@@ -13,7 +13,7 @@ image: /img/mg-preview.png
 
 ## Overview
 
-Metadata provides additional context and information for entities (clients, channels, groups, and domains) in Magistrala. The metadata system supports various value types including text, numbers, booleans, JSON objects, locations, and perimeters.
+Metadata provides additional context and information for entities (devices, channels, groups, and workspaces) in Magistrala. The metadata system supports various value types including text, numbers, booleans, JSON objects, locations, and perimeters.
 
 ## Managing Metadata
 

--- a/content/docs/user-guide/pats.mdx
+++ b/content/docs/user-guide/pats.mdx
@@ -27,12 +27,14 @@ This action redirects the user to the PAT creation page, where required details 
 
 ![Create Pat](../img/pats/create-pat.png)
 
-Available scope entities are **Clients**, **Channels**, **Groups**, and **Domain**. Each entity type exposes a distinct set of operations:
+Available scope entities are **Clients**, **Channels**, **Groups**, **Workspace**, **Rules**, **Reports**, and **Bootstrap**. Each entity type exposes a distinct set of operations:
 
 #### Clients
 
+> The scope entity is still labeled **Clients** in the PAT scope selector even though this same entity is called **Device** elsewhere in the product — the rename hasn't reached this part of the UI yet.
+
 | Operation                  | Description                              |
-| -------------------------- | ---------------------------------------- |
+| --------------------------- | ---------------------------------------- |
 | `create`                   | Creates a client                         |
 | `view`                     | View a client                            |
 | `update`                   | Update client information                |
@@ -85,27 +87,29 @@ Available scope entities are **Clients**, **Channels**, **Groups**, and **Domain
 | `set_child_channel`          | Assign a channel as a child of the group     |
 | `remove_child_channel`       | Remove a channel from the group              |
 
-#### Domain
+#### Workspace
 
-The **Domain** entity scope is automatically locked to the current domain.
+The **Workspace** entity scope is automatically locked to the current workspace.
 
-| Operation                | Description                              |
-| ------------------------ | ---------------------------------------- |
-| `update`                 | Update domain information                |
-| `read`                   | Read domain details                      |
-| `enable`                 | Enable the domain                        |
-| `disable`                | Disable the domain                       |
-| `list`                   | List domains                             |
-| `send_invitation`        | Send a domain invitation                 |
-| `list_invitation`        | List invitations sent by the user        |
-| `list_domain_invitation` | List all invitations for the domain      |
-| `delete_invitation`      | Delete a domain invitation               |
-| `create_clients`         | Create clients within the domain         |
-| `list_clients`           | List clients in the domain               |
-| `create_channels`        | Create channels within the domain        |
-| `list_channels`          | List channels in the domain              |
-| `create_groups`          | Create groups within the domain          |
-| `list_groups`            | List groups in the domain                |
+| Operation                    | Description                              |
+| ------------------------------ | ---------------------------------------- |
+| `update`                     | Update workspace information             |
+| `read`                       | Read workspace details                   |
+| `enable`                     | Enable the workspace                     |
+| `disable`                    | Disable the workspace                    |
+| `list`                       | List workspaces                          |
+| `send_invitation`            | Send a workspace invitation              |
+| `list_invitation`            | List invitations sent by the user        |
+| `list_workspace_invitation`  | List all invitations for the workspace   |
+| `delete_invitation`          | Delete a workspace invitation            |
+| `create_clients`             | Create clients within the workspace      |
+| `list_clients`               | List clients in the workspace            |
+| `create_channels`            | Create channels within the workspace     |
+| `list_channels`              | List channels in the workspace           |
+| `create_groups`              | Create groups within the workspace       |
+| `list_groups`                | List groups in the workspace             |
+
+There's no `create` operation here — a Workspace-scoped PAT is always locked to a workspace that already exists, so it can't be used to create a new one.
 
 #### Rules
 
@@ -142,6 +146,21 @@ The **Domain** entity scope is automatically locked to the current domain.
 | `update_template`      | Update the report template                       |
 | `view_template`        | View the report template                         |
 | `delete_template`      | Delete the report template                       |
+
+#### Bootstrap
+
+| Operation         | Description                                    |
+| ------------------ | ------------------------------------------------- |
+| `create`          | Create a Bootstrap configuration                  |
+| `view`            | View a Bootstrap configuration                    |
+| `update`          | Update a Bootstrap configuration                  |
+| `delete`          | Delete a Bootstrap configuration                  |
+| `enable`          | Enable a Bootstrap configuration                  |
+| `disable`         | Disable a Bootstrap configuration                 |
+| `create_profile`  | Create a Bootstrap profile                        |
+| `view_profile`    | View a Bootstrap profile                          |
+| `update_profile`  | Update a Bootstrap profile                        |
+| `delete_profile`  | Delete a Bootstrap profile                        |
 
 ## View a PAT
 

--- a/content/docs/user-guide/profile-management.mdx
+++ b/content/docs/user-guide/profile-management.mdx
@@ -23,7 +23,7 @@ Clicking the `user profile picture` or `avatar` at the top right opens a popover
 ## Standard User Menu
 
 - **Profile** (`⇧⌘P`)
-- **Switch Domains** (`⇧⌘D`)
+- **Switch Workspaces** (`⇧⌘D`)
 - **Logout** (`⇧⌘Q`)
 
 ![User Popover](../img/profile-management/jdoe-popover.png)

--- a/content/docs/user-guide/reports.mdx
+++ b/content/docs/user-guide/reports.mdx
@@ -176,7 +176,7 @@ To update the **Role Actions**, click on the **pencil** icon. A dialog box will 
 
  ![Update role actions](../img/reports/report-update-role-actions.png)
 
-To update the **Role Members**, click the **Add Members** button. A popup dialog will appear with the list of Domain Members from which a user can select.
+To update the **Role Members**, click the **Add Members** button. A popup dialog will appear with the list of Workspace Members from which a user can select.
 
  ![Update role members](../img/reports/report-role-update-members.png)
 
@@ -198,7 +198,7 @@ To delete specific members from the Role Members table, click on the **trash** i
 
 While members can be added through the **Roles** tab when creating a role, you can also assign members directly through the **Members** section.
 
-Clicking the **Assign Member** button opens a dialog where you can select from the Domain Members and choose the role to assign them to.
+Clicking the **Assign Member** button opens a dialog where you can select from the Workspace Members and choose the role to assign them to.
 
  ![Assign Members](../img/reports/report-members.png)
 

--- a/content/docs/user-guide/rules-engine/custom-nodes.mdx
+++ b/content/docs/user-guide/rules-engine/custom-nodes.mdx
@@ -14,7 +14,7 @@ image: /img/mg-preview.png
 
 ## Overview
 
-**Custom Nodes** let you define reusable logic scripts that can be used as logic nodes across multiple rules in the same domain. Instead of writing the same Lua or Go script in every rule, you create a Custom Node once and select it whenever you need that logic.
+**Custom Nodes** let you define reusable logic scripts that can be used as logic nodes across multiple rules in the same workspace. Instead of writing the same Lua or Go script in every rule, you create a Custom Node once and select it whenever you need that logic.
 
 Custom Nodes support versioning — every time you save changes to a node, its version number increments. Rules that already use the node are not automatically updated; you must explicitly sync them to adopt the new version.
 

--- a/content/docs/user-guide/rules-engine/overview.mdx
+++ b/content/docs/user-guide/rules-engine/overview.mdx
@@ -585,7 +585,7 @@ To create a role, navigate to the **Roles** tab on the rule sidebar. Click on th
 
 The **Role name** is compulsory. You can optionally provide the role actions by selecting from the available actions. You can also optionally provide the members by searching for a user with their **username**.
 
-> As with clients, channels and groups (see [Domain Roles](/user-guide/domain-management/domain#domain-roles)), rule roles use the platform's generic action vocabulary rather than rule-specific action names:
+> As with devices, channels and groups (see [Workspace Roles](/user-guide/workspace-management/workspace#workspace-roles)), rule roles use the platform's generic action vocabulary rather than rule-specific action names:
 >
 > - read
 > - write
@@ -605,7 +605,7 @@ To update the role's permissions, use the **Add actions** / **Remove actions** b
 
  ![Update role actions](../../img/rules/rule-update-role-actions.png) 
 
-To update the **Role Members**, click the **Add Members** button. A popup dialog will appear with the list of Domain Members from which a user can select.
+To update the **Role Members**, click the **Add Members** button. A popup dialog will appear with the list of Workspace Members from which a user can select.
 
  ![Update role members](../../img/rules/rule-update-role-members.png) 
 
@@ -627,7 +627,7 @@ To delete specific members from the Role Members table, click on the **trash** i
 
 While members can be added through the **Roles** tab when creating a role, you can also assign members directly through the **Members** tab.
 
-Clicking the **Assign Member** button opens a dialog where you can select from the Domain Members and choose the role to assign them to.
+Clicking the **Assign Member** button opens a dialog where you can select from the Workspace Members and choose the role to assign them to.
 
  ![Assign Members](../../img/rules/rule-members.png) 
 

--- a/content/docs/user-guide/solution-packs/cold-storage-monitoring.mdx
+++ b/content/docs/user-guide/solution-packs/cold-storage-monitoring.mdx
@@ -1,0 +1,263 @@
+---
+title: Cold Storage Monitoring
+description: The Cold Storage Monitoring solution pack connects temperature and humidity sensors, CO2 monitors, door sensors, a power supply monitor, and refrigeration energy meters to a single HACCP-aligned monitoring platform. Built for cold chain operators who need continuous frozen/chilled zone telemetry, immediate temperature and power-failure alerts, and automated compliance reporting, without custom integration work.
+keywords:
+  - Solution packs
+  - Cold storage monitoring
+  - HACCP compliance
+  - Cold chain IoT
+  - Temperature monitoring
+  - Refrigeration monitoring
+  - Magistrala solutions
+image: /img/mg-preview.png
+---
+
+## Overview
+
+The pack monitors two cold storage zones — a frozen room (target -20°C) and a chilled room (target +3°C) — from field sensors through to the dashboards facility managers and food safety officers use every day.
+
+Readings from all ten field devices (two temperature/humidity sensors, an ambient monitoring station, two CO2 sensors, two door sensors, a power supply monitor, and two refrigeration energy meters) arrive in the Telemetry Channel. Eight detection rules run continuously, watching for temperature excursions in either zone, high humidity, elevated CO2, doors left open, grid power failure, undervoltage, low backup battery, and refrigeration energy anomalies. When a HACCP-relevant threshold is crossed, alarms fire within seconds and email notifications go out to facility managers and food safety officers. A separate Commands Channel carries alarm-silence acknowledgements and threshold override commands.
+
+Operators work with three pre-built dashboards: a Cold Storage Operations Overview with live zone conditions and device/zone maps, an Energy & Power dashboard for refrigeration load and backup power status, and an Alarm Monitoring triage screen. A Cold Room Status template lets you assign a per-facility customer view scoped to their own storage unit without duplicating any dashboard configuration.
+
+## Key Features
+
+**End-to-end cold chain telemetry pipeline.** The pack provisions ten device clients across two independent storage zones, three channels (Telemetry, Commands, and Alerts), and three groups for access control (Cold Room A — Frozen Storage, Cold Room B — Chilled Storage, and Power Systems). Every SenML record that arrives in the Telemetry Channel is processed continuously by detection rules, so alarm latency is governed by your device's publish interval, not a polling schedule.
+
+**HACCP-aligned dual-zone temperature monitoring.** The frozen zone (Cold Room A, -20°C target) raises a Warning when temperature rises above -15°C and escalates to Critical at the HACCP limit of -12°C; it also warns if the zone runs colder than -26°C (freezer burn / energy waste risk). The chilled zone (Cold Room B, +3°C target) raises a Warning above 5°C, a Critical alarm at the HACCP limit of 8°C, and a High-severity alarm if it drops to or below 0°C, where refrigerated product may begin freezing.
+
+**Humidity and CO2 safety monitoring.** The Humidity Alert warns at >85% relative humidity (condensation and mold risk) and escalates to Critical at >95% (likely iced or failed evaporator). The CO2 Alert warns at >2,000 ppm and reaches Critical at >5,000 ppm — the OSHA 8-hour TWA limit — for worker safety in confined cold rooms.
+
+**Door event tracking.** The Door Open Alert monitors cumulative open duration for both cold room doors, warning at 120 seconds and escalating to Critical at 300 seconds, to limit thermal ingress and energy loss from doors left open during loading.
+
+**Power continuity and backup protection.** The Power Failure Alert raises an immediate Critical alarm the moment the facility switches to battery backup, and a Critical Grid Undervoltage alarm fires below 180V — outside the safe range for compressor motors. The Backup Battery Alert warns at <20% charge and reaches Critical at <10%, so there's lead time to start a generator or restore grid power before backup runtime runs out.
+
+**Refrigeration energy anomaly detection.** The Energy Anomaly Alert monitors compressor power draw per unit, warning above 5,000W and reaching Critical above 7,000W — both well above the normal 1,500–4,000W operating range — flagging dirty condenser coils, refrigerant leaks, or a failing compressor motor before a full breakdown.
+
+**Role-based dashboards and a customer template.** Three operational dashboards serve workspace admins: Cold Storage Operations Overview for live zone conditions, Energy & Power for refrigeration load and backup status, and Alarm Monitoring for triage. The Cold Room Status template uses tag-based device references so the same definition scales to any number of facilities or customer accounts without duplicating configuration.
+
+**Automated compliance reporting.** Three report schedules run without manual intervention: a daily temperature log for HACCP traceability, a weekly energy report for compressor efficiency tracking, and a monthly compliance report for regulatory audits and food safety certification.
+
+## Getting Started
+
+### Prerequisites
+
+Before deploying the solution pack, confirm the following:
+
+- A Magistrala domain is provisioned and you have administrator credentials.
+- At least one compatible field device is available: a temperature/humidity sensor, a CO2 sensor, a door sensor, a power supply monitor, or an energy meter capable of reporting compressor power draw.
+- Your device supports MQTT, HTTP, CoAP, or WebSocket and can publish JSON-encoded SenML payloads.
+- If you want email delivery for alarms and reports, SMTP credentials are configured in the platform settings.
+
+### Connecting Your Device
+
+**Step 1: Provision credentials from the platform.**
+
+Navigate to your domain's Clients section and create a new client for each device. The platform will generate a `client_id` and `client_secret`. Note the channel ID of the Telemetry Channel; you will find it in the Channels section after the solution pack is deployed.
+
+**Step 2: Configure your device.**
+
+| Parameter | Value                            |
+| --------- | -------------------------------- |
+| Broker    | `<your-magistrala-domain>`       |
+| Port      | `1883` (plain) or `8883` (TLS)   |
+| Topic     | `channels/<channel_id>/messages` |
+| Username  | `<client_id>`                    |
+| Password  | `<client_secret>`                |
+
+Use TLS (port 8883) in production. Plain MQTT (port 1883) is suitable for local development and testing only.
+
+**Step 3: Publish your first SenML payload.**
+
+```json
+[
+  { "bn": "cold-room-a-sensor-001:", "bt": 1750000000, "bu": "Cel", "bver": 5 },
+  { "n": "temperature",          "u": "Cel", "v": -19.4 },
+  { "n": "humidity",             "u": "%",   "v": 72.5  },
+  { "n": "co2_level",            "u": "ppm", "v": 850.0 },
+  { "n": "door_status",          "u": "",    "v": 0     },
+  { "n": "door_open_duration",   "u": "s",   "v": 0.0   },
+  { "n": "grid_voltage",         "u": "V",   "v": 228.5 },
+  { "n": "power_source",         "u": "",    "v": 0     },
+  { "n": "energy_consumption",   "u": "kWh", "v": 125.4 },
+  { "n": "power_draw",           "u": "W",   "v": 2850.0 },
+  { "n": "battery_backup_level", "u": "%",   "v": 95.0  },
+  { "n": "compressor_status",    "u": "",    "v": 1     }
+]
+```
+
+Not every device needs to report every field — a temperature/humidity sensor publishes `temperature` and `humidity`; a door sensor publishes `door_status` and `door_open_duration`; an energy meter publishes `power_draw`, `energy_consumption`, and `compressor_status`. Only include the fields your device actually measures. After publishing, check the Telemetry Channel's message log in the platform UI to confirm the payload arrived.
+
+### Supported Protocols
+
+| Protocol        | Port | Notes                                                              |
+| ---------------- | ---- | -------------------------------------------------------------------- |
+| MQTT             | 1883 | Plain TCP. Development and LAN use only.                            |
+| MQTT (TLS)       | 8883 | Recommended for production deployments.                             |
+| HTTP             | 80   | POST to `http://<domain>/http/channels/<channel_id>/messages`.      |
+| HTTPS            | 443  | Recommended for HTTP-based devices.                                 |
+| CoAP             | 5683 | UDP. Suitable for low-power constrained field sensors.               |
+| CoAP (DTLS)      | 5684 | Datagram TLS. Constrained devices in untrusted networks.             |
+| WebSocket        | 8080 | For browser-based or gateway streaming integrations.                 |
+| WebSocket (TLS)  | 8443 | Secure WebSocket.                                                    |
+
+## Dashboard Guide
+
+### Cold Storage Operations Overview
+
+The primary operations view for facility managers: live temperature and humidity gauges for both cold rooms, ambient temperature, CO2 value cards, door status indicators, active alarm count, 24-hour temperature trend charts, and two maps.
+
+**Temperature — Cold Room A** is a gauge scaled -30°C to 0°C for the frozen zone. **Temperature — Cold Room B** is a gauge scaled -5°C to +15°C for the chilled zone. **Ambient Temperature** is a gauge fed by the loading-area monitoring station. **Humidity — Cold Room A/B** are 0–100% gauges. **CO2 Level — Cold Room A/B** are value cards in ppm. **Door Status — Cold Room A/B** are value cards showing open/closed state. **Active Alarms** is a count card for all open alarms. **Temperature Trend — Cold Room A/B** are 24-hour line charts. **Facility Device Map** is a marker map plotting all ten sensors and meters at their installation coordinates. **Cold Room Zone Map** is a polygon map showing the Cold Room A and Cold Room B perimeters with device markers inside each zone.
+
+Before this dashboard displays correctly, verify that the `location` metadata on each device client matches your actual facility coordinates — the pack ships with sample coordinates for a Hamburg, Germany warehouse.
+
+### Energy & Power Dashboard
+
+The energy and power management view for operations engineers: live power draw gauges for both refrigeration units, backup battery level, grid voltage, 24-hour energy consumption bar charts, and a device map.
+
+**Power Draw — Refrigeration Unit A/B** are gauges scaled 0–8,000W. **Backup Battery Level** is a 0–100% gauge. **Grid Voltage** is a value card in volts. **Energy Consumption — Unit A/B** are 24-hour bar charts (kWh aggregated per hour). **Power & Energy Device Map** is a marker map showing the Power Supply Monitor and both Energy Meters at their installation coordinates.
+
+### Alarm Monitoring Dashboard
+
+The alarm triage centre: live counts by severity and a full alarm table for acknowledgement and resolution. **Total Active Alarms** counts all open alarms. **Critical Alarms** and **High Severity Alarms** and **Medium Severity Alarms** count cards are filtered by severity. **All Alarms** is a full alarm table with severity, status, measurement, cause, value, threshold, and timestamps.
+
+### Cold Room Status Template
+
+A customer-facing dashboard template showing live temperature, humidity, CO2 level, door status, and a 24-hour temperature trend for the assigned storage unit. It uses tag-based device references (`device:temp-humidity`, `device:co2-sensor`, `device:door-sensor`), so the same template definition applies to any cold room when assigned to a group containing devices with those tags. Follow the Dashboard Template documentation to assign it to customers.
+
+## Rules & Automation
+
+### Save Messages
+
+Passes all SenML records that contain a numeric `v` field through to storage, ensuring raw device data is always persisted.
+
+- **Input:** Telemetry Channel · **Output:** save_senml
+
+### Temperature Alert
+
+Monitors `temperature` and raises zone-specific alarms: **Frozen Zone Temperature Warning** (>-15°C, Warning), **Frozen Zone Temperature Critical** (>-12°C, Critical — HACCP limit), **Frozen Zone Overcooled** (<-26°C, Warning), **Chilled Zone Temperature Warning** (>5°C, Warning), **Chilled Zone Temperature Critical** (>8°C, Critical — HACCP limit), **Chilled Zone Too Cold** (≤0°C, High).
+
+- **Outputs:** alarms, channels → Alerts Channel, email
+
+### Humidity Alert
+
+Monitors `humidity`: Warning above 85%, Critical above 95%.
+
+- **Outputs:** alarms, channels → Alerts Channel, email
+
+### CO2 Alert
+
+Monitors `co2_level`: Warning above 2,000 ppm, Critical above 5,000 ppm (OSHA 8-hour TWA limit).
+
+- **Outputs:** alarms, channels → Alerts Channel, email
+
+### Door Open Alert
+
+Monitors `door_open_duration`: Warning above 120 seconds, Critical above 300 seconds.
+
+- **Outputs:** alarms, channels → Alerts Channel, email
+
+### Power Failure Alert
+
+Monitors `power_source`: an immediate Critical alarm fires when the value indicates battery backup is active (grid failure). Also raises a Critical **Grid Undervoltage** alarm when `grid_voltage` drops below 180V.
+
+- **Outputs:** alarms, channels → Alerts Channel, email
+
+### Energy Anomaly Alert
+
+Monitors `power_draw` per refrigeration unit: Warning above 5,000W, Critical above 7,000W.
+
+- **Outputs:** alarms, channels → Alerts Channel, email
+
+### Backup Battery Alert
+
+Monitors `battery_backup_level`: Warning below 20%, Critical below 10%.
+
+- **Outputs:** alarms, channels → Alerts Channel, email
+
+## Alarms Reference
+
+| Alarm Name                       | Trigger Condition                              | Severity     | Recommended Action                                                                    |
+| ---------------------------------- | ------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------- |
+| Frozen Zone Temperature Critical | `temperature` > -12°C (Cold Room A)              | Critical (5) | Inspect refrigeration and door seals; transfer product if not restored within 30 min. |
+| Frozen Zone Temperature Warning  | `temperature` > -15°C (Cold Room A)              | Warning (3)  | Check refrigeration unit and door seals before the -12°C HACCP limit is reached.      |
+| Frozen Zone Overcooled           | `temperature` < -26°C (Cold Room A)              | Warning (3)  | Check thermostat/refrigerant charge; risk of freezer burn and excess energy use.      |
+| Chilled Zone Temperature Critical | `temperature` > 8°C (Cold Room B)                | Critical (5) | Inspect stock for spoilage; notify the food safety officer immediately.               |
+| Chilled Zone Temperature Warning | `temperature` > 5°C (Cold Room B)                | Warning (3)  | Check door seals, cooling unit, nearby heat sources before the 8°C limit is reached.  |
+| Chilled Zone Too Cold            | `temperature` ≤ 0°C (Cold Room B)                | High (4)     | Check thermostat settings; risk of freezing chilled product.                          |
+| High Humidity                    | `humidity` > 85%                                 | Warning (3)  | Inspect for condensation/ice build-up on coils and packaging mold risk.               |
+| Critical Humidity                | `humidity` > 95%                                 | Critical (5) | Inspect for iced/failed evaporator; initiate manual defrost if blocked.               |
+| CO2 Level High                   | `co2_level` > 2,000 ppm                          | Warning (3)  | Limit worker exposure; check ventilation before extended entry.                       |
+| CO2 Level Critical               | `co2_level` > 5,000 ppm                          | Critical (5) | Do not enter without breathing apparatus; evacuate and ventilate immediately.         |
+| Door Left Open                   | `door_open_duration` > 120s                      | Warning (3)  | Confirm whether an intended access or an unintended open door.                        |
+| Door Extended Open               | `door_open_duration` > 300s                      | Critical (5) | Close the door immediately; verify loading dock seals if a loading operation.         |
+| Grid Power Failure               | `power_source` = 2 (battery backup active)       | Critical (5) | Contact grid operator, start standby generator, prepare for controlled shutdown.      |
+| Grid Undervoltage                | `grid_voltage` < 180V                            | Critical (5) | Switch to backup power or shut down refrigeration until voltage is restored.          |
+| Backup Battery Low               | `battery_backup_level` < 20%                     | Warning (3)  | Verify battery health; schedule a capacity test.                                      |
+| Backup Battery Critical          | `battery_backup_level` < 10%                     | Critical (5) | Notify operations staff immediately; equipment shutdown may be imminent.              |
+| Refrigeration Energy Anomaly     | `power_draw` > 5,000W per unit                   | Warning (3)  | Schedule a maintenance inspection (coils, refrigerant leak, compressor).              |
+| Refrigeration Fault              | `power_draw` > 7,000W per unit                   | Critical (5) | Dispatch a refrigeration engineer immediately; consider manual failover.              |
+
+## Reports
+
+### Daily Temperature Log
+
+Delivers a daily HACCP traceability log of zone temperatures. Use it as the record of continuous compliance for food safety audits.
+
+### Weekly Energy Report
+
+Delivers a weekly summary of refrigeration energy consumption per unit. Use it to track compressor efficiency and spot units trending toward the Energy Anomaly thresholds before they alarm.
+
+### Monthly Compliance Report
+
+Delivers a monthly HACCP compliance summary across both zones. Use it for regulatory audits and food safety certification renewal.
+
+> All three reports are delivered by email. Update the recipient addresses in the Reports page before relying on them — the pack ships with placeholder recipients that are not deliverable.
+
+## Payload Reference
+
+| Field Name              | Unit | Description                                                                                                          | Example Value |
+| -------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `temperature`            | Cel  | Storage zone air temperature. Frozen zone target -20°C, chilled zone target +3°C. See Alarms Reference for thresholds. | -19.4          |
+| `humidity`                | %    | Relative humidity in the storage zone. Warning at >85%, critical at >95%.                                              | 72.5           |
+| `co2_level`               | ppm  | CO2 concentration. Warning at >2,000 ppm, critical at >5,000 ppm.                                                      | 850.0          |
+| `door_status`             | -    | 0 = closed, 1 = open. Sent on state change and every 30s while open.                                                   | 0              |
+| `door_open_duration`      | s    | Cumulative seconds the door has been continuously open, resets on close. Warning at >120s, critical at >300s.         | 0.0            |
+| `grid_voltage`            | V    | Mains supply voltage at the switchboard. Below 180V is critical undervoltage. Normal range 207–253V (EU standard).     | 228.5          |
+| `power_source`            | -    | 0 = grid, 1 = solar only, 2 = battery backup (grid failure — triggers a critical alarm).                              | 0              |
+| `energy_consumption`      | kWh  | Cumulative refrigeration unit energy since last reset. Used in weekly energy reporting.                                | 125.4          |
+| `power_draw`              | W    | Current compressor power draw. Normal range 1,500–4,000W; warning above 5,000W, critical above 7,000W.                | 2850.0         |
+| `battery_backup_level`    | %    | UPS/backup battery charge. Warning below 20%, critical below 10%.                                                      | 95.0           |
+| `compressor_status`       | -    | 0 = off (defrost/fault), 1 = running.                                                                                  | 1              |
+
+## Troubleshooting
+
+**Messages are not appearing in the Telemetry Channel.**
+
+Check that the MQTT client uses the topic format `channels/<channel_id>/messages` for the Telemetry Channel (not Commands or Alerts), and that `username`/`password` are the `client_id`/`client_secret` from the Clients section, not the display name.
+
+**Messages arrive but no alarms fire.**
+
+Detection rules match exact field names: `temperature`, `humidity`, `co2_level`, `door_open_duration`, `power_source`, `grid_voltage`, `power_draw`, `battery_backup_level`. Verify the `n` field in each SenML record against the Payload Reference table above.
+
+**Grid Power Failure alarm fires but the facility is on generator, not battery.**
+
+The rule only inspects `power_source`; a value of `2` always means battery backup regardless of whether a generator is also running. If your site treats generator power as a distinct source, report it as a separate `power_source` value in your device firmware and note that this rule currently only distinguishes grid/solar/battery.
+
+**Reports are not being delivered by email.**
+
+Confirm SMTP credentials are configured in the platform settings and that the placeholder recipient addresses in each report have been replaced with valid ones for your organisation.
+
+## FAQ
+
+**Can the pack monitor more than two cold rooms?**
+
+Yes. The pack ships with two zones (Cold Room A, frozen; Cold Room B, chilled), but the architecture scales to any number. Each additional room needs its own device clients, a group for access control, and Telemetry Channel connections. The Cold Room Status template scales automatically to any group containing devices tagged `device:temp-humidity`, `device:co2-sensor`, and `device:door-sensor`.
+
+**Can we monitor a third temperature band, like a dry storage or ambient zone?**
+
+Yes — connect a temperature/humidity sensor to the Telemetry Channel with its own zone tag and metadata. It will appear on the Facility Device Map immediately; add it to the Operations Overview dashboard manually if you want a dedicated gauge for it, since the Temperature Alert rule as shipped only evaluates the frozen and chilled zone thresholds.
+
+**How often should devices publish for effective alarm detection?**
+
+Temperature and humidity change gradually — every 1–5 minutes is sufficient. Door sensors should publish on every state change plus a heartbeat every 30 seconds while open, so `door_open_duration` tracks accurately. Power and energy readings at 60-second intervals are adequate for both alarm detection and energy reporting.

--- a/content/docs/user-guide/solution-packs/cold-storage-monitoring.mdx
+++ b/content/docs/user-guide/solution-packs/cold-storage-monitoring.mdx
@@ -22,7 +22,7 @@ Operators work with three pre-built dashboards: a Cold Storage Operations Overvi
 
 ## Key Features
 
-**End-to-end cold chain telemetry pipeline.** The pack provisions ten device clients across two independent storage zones, three channels (Telemetry, Commands, and Alerts), and three groups for access control (Cold Room A — Frozen Storage, Cold Room B — Chilled Storage, and Power Systems). Every SenML record that arrives in the Telemetry Channel is processed continuously by detection rules, so alarm latency is governed by your device's publish interval, not a polling schedule.
+**End-to-end cold chain telemetry pipeline.** The pack provisions ten devices across two independent storage zones, three channels (Telemetry, Commands, and Alerts), and three groups for access control (Cold Room A — Frozen Storage, Cold Room B — Chilled Storage, and Power Systems). Every SenML record that arrives in the Telemetry Channel is processed continuously by detection rules, so alarm latency is governed by your device's publish interval, not a polling schedule.
 
 **HACCP-aligned dual-zone temperature monitoring.** The frozen zone (Cold Room A, -20°C target) raises a Warning when temperature rises above -15°C and escalates to Critical at the HACCP limit of -12°C; it also warns if the zone runs colder than -26°C (freezer burn / energy waste risk). The chilled zone (Cold Room B, +3°C target) raises a Warning above 5°C, a Critical alarm at the HACCP limit of 8°C, and a High-severity alarm if it drops to or below 0°C, where refrigerated product may begin freezing.
 
@@ -44,7 +44,7 @@ Operators work with three pre-built dashboards: a Cold Storage Operations Overvi
 
 Before deploying the solution pack, confirm the following:
 
-- A Magistrala domain is provisioned and you have administrator credentials.
+- A Magistrala workspace is provisioned and you have administrator credentials.
 - At least one compatible field device is available: a temperature/humidity sensor, a CO2 sensor, a door sensor, a power supply monitor, or an energy meter capable of reporting compressor power draw.
 - Your device supports MQTT, HTTP, CoAP, or WebSocket and can publish JSON-encoded SenML payloads.
 - If you want email delivery for alarms and reports, SMTP credentials are configured in the platform settings.
@@ -53,7 +53,7 @@ Before deploying the solution pack, confirm the following:
 
 **Step 1: Provision credentials from the platform.**
 
-Navigate to your domain's Clients section and create a new client for each device. The platform will generate a `client_id` and `client_secret`. Note the channel ID of the Telemetry Channel; you will find it in the Channels section after the solution pack is deployed.
+Navigate to your workspace's Devices section and create a new device for each sensor. The platform will generate a `client_id` and `client_secret`. Note the channel ID of the Telemetry Channel; you will find it in the Channels section after the solution pack is deployed.
 
 **Step 2: Configure your device.**
 
@@ -109,7 +109,7 @@ The primary operations view for facility managers: live temperature and humidity
 
 **Temperature — Cold Room A** is a gauge scaled -30°C to 0°C for the frozen zone. **Temperature — Cold Room B** is a gauge scaled -5°C to +15°C for the chilled zone. **Ambient Temperature** is a gauge fed by the loading-area monitoring station. **Humidity — Cold Room A/B** are 0–100% gauges. **CO2 Level — Cold Room A/B** are value cards in ppm. **Door Status — Cold Room A/B** are value cards showing open/closed state. **Active Alarms** is a count card for all open alarms. **Temperature Trend — Cold Room A/B** are 24-hour line charts. **Facility Device Map** is a marker map plotting all ten sensors and meters at their installation coordinates. **Cold Room Zone Map** is a polygon map showing the Cold Room A and Cold Room B perimeters with device markers inside each zone.
 
-Before this dashboard displays correctly, verify that the `location` metadata on each device client matches your actual facility coordinates — the pack ships with sample coordinates for a Hamburg, Germany warehouse.
+Before this dashboard displays correctly, verify that the `location` metadata on each device's record matches your actual facility coordinates — the pack ships with sample coordinates for a Hamburg, Germany warehouse.
 
 ### Energy & Power Dashboard
 
@@ -234,7 +234,7 @@ Delivers a monthly HACCP compliance summary across both zones. Use it for regula
 
 **Messages are not appearing in the Telemetry Channel.**
 
-Check that the MQTT client uses the topic format `channels/<channel_id>/messages` for the Telemetry Channel (not Commands or Alerts), and that `username`/`password` are the `client_id`/`client_secret` from the Clients section, not the display name.
+Check that the MQTT client uses the topic format `channels/<channel_id>/messages` for the Telemetry Channel (not Commands or Alerts), and that `username`/`password` are the `client_id`/`client_secret` from the Devices section, not the display name.
 
 **Messages arrive but no alarms fire.**
 
@@ -252,7 +252,7 @@ Confirm SMTP credentials are configured in the platform settings and that the pl
 
 **Can the pack monitor more than two cold rooms?**
 
-Yes. The pack ships with two zones (Cold Room A, frozen; Cold Room B, chilled), but the architecture scales to any number. Each additional room needs its own device clients, a group for access control, and Telemetry Channel connections. The Cold Room Status template scales automatically to any group containing devices tagged `device:temp-humidity`, `device:co2-sensor`, and `device:door-sensor`.
+Yes. The pack ships with two zones (Cold Room A, frozen; Cold Room B, chilled), but the architecture scales to any number. Each additional room needs its own devices, a group for access control, and Telemetry Channel connections. The Cold Room Status template scales automatically to any group containing devices tagged `device:temp-humidity`, `device:co2-sensor`, and `device:door-sensor`.
 
 **Can we monitor a third temperature band, like a dry storage or ambient zone?**
 

--- a/content/docs/user-guide/solution-packs/cold-storage-monitoring.mdx
+++ b/content/docs/user-guide/solution-packs/cold-storage-monitoring.mdx
@@ -30,7 +30,7 @@ Operators work with three pre-built dashboards: a Cold Storage Operations Overvi
 
 **Door event tracking.** The Door Open Alert monitors cumulative open duration for both cold room doors, warning at 120 seconds and escalating to Critical at 300 seconds, to limit thermal ingress and energy loss from doors left open during loading.
 
-**Power continuity and backup protection.** The Power Failure Alert raises an immediate Critical alarm the moment the facility switches to battery backup, and a Critical Grid Undervoltage alarm fires below 180V — outside the safe range for compressor motors. The Backup Battery Alert warns at <20% charge and reaches Critical at <10%, so there's lead time to start a generator or restore grid power before backup runtime runs out.
+**Power continuity and backup protection.** The Power Failure Alert raises an immediate Critical alarm the moment the facility switches to battery backup, and a Critical Grid Undervoltage alarm fires below 180V — outside the safe range for compressor motors. The Backup Battery Alert warns below 20% charge and reaches Critical below 10%, so there's lead time to start a generator or restore grid power before backup runtime runs out.
 
 **Refrigeration energy anomaly detection.** The Energy Anomaly Alert monitors compressor power draw per unit, warning above 5,000W and reaching Critical above 7,000W — both well above the normal 1,500–4,000W operating range — flagging dirty condenser coils, refrigerant leaks, or a failing compressor motor before a full breakdown.
 
@@ -135,7 +135,7 @@ Passes all SenML records that contain a numeric `v` field through to storage, en
 
 ### Temperature Alert
 
-Monitors `temperature` and raises zone-specific alarms: **Frozen Zone Temperature Warning** (>-15°C, Warning), **Frozen Zone Temperature Critical** (>-12°C, Critical — HACCP limit), **Frozen Zone Overcooled** (<-26°C, Warning), **Chilled Zone Temperature Warning** (>5°C, Warning), **Chilled Zone Temperature Critical** (>8°C, Critical — HACCP limit), **Chilled Zone Too Cold** (≤0°C, High).
+Monitors `temperature` and raises zone-specific alarms: **Frozen Zone Temperature Warning** (above -15°C, Warning), **Frozen Zone Temperature Critical** (above -12°C, Critical — HACCP limit), **Frozen Zone Overcooled** (below -26°C, Warning), **Chilled Zone Temperature Warning** (above 5°C, Warning), **Chilled Zone Temperature Critical** (above 8°C, Critical — HACCP limit), **Chilled Zone Too Cold** (≤0°C, High).
 
 - **Outputs:** alarms, channels → Alerts Channel, email
 

--- a/content/docs/user-guide/solution-packs/meta.json
+++ b/content/docs/user-guide/solution-packs/meta.json
@@ -4,6 +4,7 @@
     "overview",
     "smart-water-metering",
     "smart-irrigation",
-    "oil-gas-field-monitoring"
+    "oil-gas-field-monitoring",
+    "cold-storage-monitoring"
   ]
 }

--- a/content/docs/user-guide/solution-packs/overview.mdx
+++ b/content/docs/user-guide/solution-packs/overview.mdx
@@ -10,7 +10,7 @@ keywords:
 image: /img/mg-preview.png
 ---
 
-Solution packs are ready-made IoT solutions that you can deploy instantly from the Magistrala UI. Each pack bundles every entity required to run a real-world use case - clients, channels, groups, rules, dashboards, templates, and reports - so you go from zero to a working system without building anything from scratch.
+Solution packs are ready-made IoT solutions that you can deploy instantly from the Magistrala UI. Each pack bundles every entity required to run a real-world use case - devices, channels, groups, rules, dashboards, templates, and reports - so you go from zero to a working system without building anything from scratch.
 
 Use them to evaluate whether Magistrala fits your use case, as a reference implementation, or as a baseline you extend with your own configuration.
 
@@ -20,7 +20,7 @@ When you install a solution pack, Magistrala provisions the following entities a
 
 | Entity         | Purpose                                                                  |
 | -------------- | ------------------------------------------------------------------------ |
-| **Clients**    | Pre-configured device records for every device type in the solution      |
+| **Devices**    | Pre-configured device records for every device type in the solution      |
 | **Channels**   | Dedicated message channels (e.g. raw telemetry, processed data, alerts)  |
 | **Groups**     | Access-control groups for devices and users                              |
 | **Rules**      | Automation rules for data processing, alarm detection, and data archival |
@@ -79,7 +79,7 @@ After installation, open the solution pack and navigate to the **Instructions** 
 
 ### Deleting a Solution Pack
 
-To remove a solution pack, open it from the **Installed Solutions** list and click **Uninstall**. This removes all entities provisioned by the pack - clients, channels, groups, rules, dashboards, templates, and reports - from your workspace.
+To remove a solution pack, open it from the **Installed Solutions** list and click **Uninstall**. This removes all entities provisioned by the pack - devices, channels, groups, rules, dashboards, templates, and reports - from your workspace.
 
 ![Uninstall option on an installed solution pack](/screenshots/solutions/delete-solution.png)
 
@@ -91,7 +91,7 @@ To remove a solution pack, open it from the **Installed Solutions** list and cli
 
 Solution packs are a starting point, not a ceiling. After installation you can:
 
-- **Add devices** by creating additional clients and connecting them to the provisioned channels using the same payload schema.
+- **Add devices** by creating additional devices and connecting them to the provisioned channels using the same payload schema.
 - **Modify rules** to adjust detection thresholds or add new conditions for your specific environment.
 - **Customise dashboards** by adding, removing, or reconfiguring widgets.
 - **Create additional templates** for new zones, sites, or customer segments.
@@ -103,7 +103,7 @@ Changes you make to provisioned entities are preserved independently of the solu
 
 **Can I install more than one solution pack in the same workspace?**
 
-Yes. Multiple solution packs can coexist in the same workspace. Each pack provisions its own set of clients, channels, groups, rules, dashboards, and reports under distinct names, so there is no collision between packs.
+Yes. Multiple solution packs can coexist in the same workspace. Each pack provisions its own set of devices, channels, groups, rules, dashboards, and reports under distinct names, so there is no collision between packs.
 
 **Can I install the same solution pack more than once?**
 
@@ -111,7 +111,7 @@ No. Each solution pack can be installed once per workspace. If you need multiple
 
 **Will installing a solution pack affect my existing entities?**
 
-No. Solution pack installation only creates new entities. It does not modify, overwrite, or delete any existing clients, channels, rules, or dashboards in your workspace.
+No. Solution pack installation only creates new entities. It does not modify, overwrite, or delete any existing devices, channels, rules, or dashboards in your workspace.
 
 **Can I preview what a solution pack will create before installing?**
 

--- a/content/docs/user-guide/solution-packs/overview.mdx
+++ b/content/docs/user-guide/solution-packs/overview.mdx
@@ -36,9 +36,12 @@ Magistrala ships with an expanding library of solution packs. Each pack targets 
 
 ![Solution packs catalogue](/screenshots/solutions/solution-packs.png)
 
-| Solution Pack                                  | Industry        | Description                                                                                                                                   |
-| ---------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Smart Water Metering](./smart-water-metering) | Water Utilities | Monitor flow, pressure, and water quality across a distribution network with automated leak detection, burst alarms, and compliance reporting |
+| Solution Pack                                            | Industry          | Description                                                                                                                                 |
+| ---------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Smart Water Metering](./smart-water-metering)              | Water Utilities      | Monitor flow, pressure, and water quality across a distribution network with automated leak detection, burst alarms, and compliance reporting |
+| [Smart Irrigation](./smart-irrigation)                       | Agriculture          | Field-level soil moisture, flow, and tank monitoring with pipe-burst detection, remote valve/pump control, and weekly soil health reports     |
+| [Oil & Gas Field Monitoring](./oil-gas-field-monitoring)     | Oil & Gas            | Wellhead telemetry, H2S and pressure safety alerts, and automated production/compliance reporting for upstream operations                     |
+| [Cold Storage Monitoring](./cold-storage-monitoring)         | Cold Chain / Food    | Temperature, humidity, CO2, door, and power monitoring across frozen and chilled zones with HACCP-aligned alarms and compliance reporting     |
 
 ## Managing Solution Packs
 

--- a/content/docs/user-guide/solution-packs/overview.mdx
+++ b/content/docs/user-guide/solution-packs/overview.mdx
@@ -57,13 +57,13 @@ Browse the solution pack catalogue to read about a pack before installing it. Ea
 
 ### Installing a Solution Pack
 
-Click **Install** on any solution pack in the catalogue. Magistrala will provision all entities in your current domain. Installation typically completes in a few seconds. Once installed, the pack appears in your **Installed Solutions** list.
+Click **Install** on any solution pack in the catalogue. Magistrala will provision all entities in your current workspace. Installation typically completes in a few seconds. Once installed, the pack appears in your **Installed Solutions** list.
 
 ![Install button on a solution pack](/screenshots/solutions/install-solution.png)
 
 ![Installation confirmation dialog](/screenshots/solutions/install-solution-dialog.png)
 
-> A solution pack is always installed into the currently active domain. Make sure you are in the correct domain before installing.
+> A solution pack is always installed into the currently active workspace. Make sure you are in the correct workspace before installing.
 
 ### Viewing Instructions
 
@@ -79,7 +79,7 @@ After installation, open the solution pack and navigate to the **Instructions** 
 
 ### Deleting a Solution Pack
 
-To remove a solution pack, open it from the **Installed Solutions** list and click **Uninstall**. This removes all entities provisioned by the pack - clients, channels, groups, rules, dashboards, templates, and reports - from your domain.
+To remove a solution pack, open it from the **Installed Solutions** list and click **Uninstall**. This removes all entities provisioned by the pack - clients, channels, groups, rules, dashboards, templates, and reports - from your workspace.
 
 ![Uninstall option on an installed solution pack](/screenshots/solutions/delete-solution.png)
 
@@ -101,17 +101,17 @@ Changes you make to provisioned entities are preserved independently of the solu
 
 ## FAQ
 
-**Can I install more than one solution pack in the same domain?**
+**Can I install more than one solution pack in the same workspace?**
 
-Yes. Multiple solution packs can coexist in the same domain. Each pack provisions its own set of clients, channels, groups, rules, dashboards, and reports under distinct names, so there is no collision between packs.
+Yes. Multiple solution packs can coexist in the same workspace. Each pack provisions its own set of clients, channels, groups, rules, dashboards, and reports under distinct names, so there is no collision between packs.
 
 **Can I install the same solution pack more than once?**
 
-No. Each solution pack can be installed once per domain. If you need multiple independent deployments of the same solution (for example, separate installations for different sites), use separate domains.
+No. Each solution pack can be installed once per workspace. If you need multiple independent deployments of the same solution (for example, separate installations for different sites), use separate workspaces.
 
 **Will installing a solution pack affect my existing entities?**
 
-No. Solution pack installation only creates new entities. It does not modify, overwrite, or delete any existing clients, channels, rules, or dashboards in your domain.
+No. Solution pack installation only creates new entities. It does not modify, overwrite, or delete any existing clients, channels, rules, or dashboards in your workspace.
 
 **Can I preview what a solution pack will create before installing?**
 

--- a/content/docs/user-guide/users-quick-start.mdx
+++ b/content/docs/user-guide/users-quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quick Start Guide
-description: Get up and running with Magistrala — the open-source IoT platform. Learn how to create users, manage clients and channels, and explore key services.
+description: Get up and running with Magistrala — the open-source IoT platform. Learn how to create users, manage devices and channels, and explore key services.
 keywords:
   - Magistrala Quick Start
   - IoT Setup Guide
@@ -10,7 +10,7 @@ keywords:
 image: /img/mg-preview.png
 ---
 
-Magistrala provides core **Services** for handling the creation, deletion, updating, and retrieval of user accounts, clients and channels.
+Magistrala provides core **Services** for handling the creation, deletion, updating, and retrieval of user accounts, devices and channels.
 Users in Magistrala must have **unique credentials**, including a `username`, `secret`, and `email` address upon creation.
 
 This guide will take you through the core services for a quick setup of Magistrala and a walkthrough of its services and components.
@@ -37,7 +37,7 @@ On the **Sign Up** page, check the boxes for:
 
 Then click **Sign up with Google**.
 
-Select your Google account to complete registration. You’ll be redirected to the **Domains Homepage**, where you can create or join existing domains.
+Select your Google account to complete registration. You’ll be redirected to the **Workspaces Homepage**, where you can create or join existing workspaces.
 
 ![Google Sign Up](../img/users-guide/google-signup-page.png)
 
@@ -58,18 +58,18 @@ If the button doesn’t work, you can also copy the verification link provided i
 > The verification link is valid for **24 hours** for security reasons.  
 > If it expires or you didn’t receive the email, click **Resend Email Verification** on your profile page.
 
-Once verified, your profile status will update to **Verified**, and you’ll gain full access to the platform, including the ability to log in to domains.
+Once verified, your profile status will update to **Verified**, and you’ll gain full access to the platform, including the ability to log in to workspaces.
 
 ### After Verification
 
 After your email has been verified:
 
-- You’ll be redirected to the **Domains Homepage**.
-- From there, you can create a new domain or access any existing ones you belong to.
+- You’ll be redirected to the **Workspaces Homepage**.
+- From there, you can create a new workspace or access any existing ones you belong to.
 
-> **Tip:** If you’ve already verified your email and are still on the verification page, click **Go to Domains Page** to continue.
+> **Tip:** If you’ve already verified your email and are still on the verification page, click **Go to Workspaces Page** to continue.
 
-![Domain Homepage](../img/users-guide/janedoe-domainshome.png)
+![Workspace Homepage](../img/users-guide/janedoe-domainshome.png)
 
 ## Log In
 
@@ -89,27 +89,27 @@ Choose your preferred Google account to continue. Once authenticated, you’ll b
 > **Note:**  
 > If this is your first time signing in with Google, Magistrala will automatically create a new user profile associated with your Google email.
 
-## Log into a Domain
+## Log into a Workspace
 
-Upon logging in, users are redirected to the **Domain Selection Page**.
+Upon logging in, users are redirected to the **Workspace Selection Page**.
 
-A **Domain** is a workspace that allows you to manage **Clients**, **Channels**, **Groups**, **Dashboards**, **Members**, **Rules** and **Bootstrap** services.
+A **Workspace** lets you manage **Devices**, **Channels**, **Groups**, **Dashboards**, **Members**, **Rules** and **Bootstrap** services.
 
-Click the `+ Create` button in the top-right corner to start. In addition to the domain name, you’ll need to set a **route**, a unique, user-friendly alias for the domain’s ID. This route makes it easier to reference or subscribe to the domain without using its full UUID.
+Click the `+ Create` button in the top-right corner to start. In addition to the workspace name, you’ll need to set a **route**, a unique, user-friendly alias for the workspace’s ID. This route makes it easier to reference or subscribe to the workspace without using its full UUID.
 
 > **The route is defined only at creation and cannot be changed later, so choose something short, clear, and descriptive.**
 
-![Domain Create](../img/users-guide/jdoe-create-domain.png)
+![Workspace Create](../img/users-guide/jdoe-create-domain.png)
 
-Once you create a domain, you are given **admin** role over the domain by default. You are able to perform all actions available over the domain and all the entities provisioned inside the domain. You can also assign or invite members to the domain with various levels of permissions. Click on the respective card to log into a domain of your choice.
+Once you create a workspace, you are given **admin** role over the workspace by default. You are able to perform all actions available over the workspace and all the entities provisioned inside the workspace. You can also assign or invite members to the workspace with various levels of permissions. Click on the respective card to log into a workspace of your choice.
 
-We will delve deeper into Domains in [another section](/user-guide/domain-management/domain). For now you need to be able to log into a Domain to move on to **Groups**.
+We will delve deeper into Workspaces in [another section](/user-guide/workspace-management/workspace). For now you need to be able to log into a Workspace to move on to **Groups**.
 
 ## Create a Group
 
-Once logged in, you will be directed to the **Homepage** where you can view all the available entities in the domain.
+Once logged in, you will be directed to the **Homepage** where you can view all the available entities in the workspace.
 
-On the sidebar navigation, click on **Groups** under the _Clients Management_ section to be redirected to the groups page.
+On the sidebar navigation, click on **Groups** under the _Device Management_ section to be redirected to the groups page.
 
 ![Groups Page](../img/users-guide/jdoe-groups-page.png)
 
@@ -117,25 +117,25 @@ To create a group, click on the `+ Create` button present on the top-left corner
 
 ![Create Group](../img/users-guide/group-information.png)
 
-## Create a Client
+## Create a Device
 
-A **Client** represents a device connected to Magistrala, capable of communication with other devices.
+A **Device** represents a device connected to Magistrala, capable of communication with other devices.
 It can be a **physical** or **virtual** device that sends and receives messages, often through **embedded systems**.
 
-When you create a client within a specific group, it is automatically assigned to that group and can be connected to **any channel in the domain**.
+When you create a device within a specific group, it is automatically assigned to that group and can be connected to **any channel in the workspace**.
 
-To create a new client, go to the **Clients** page of the desired group and click the `+ Create` button.  
+To create a new device, go to the **Devices** page of the desired group and click the `+ Create` button.  
 A dialog will appear asking for details such as:
 
 - **Name** (required)
-- **Key** (optional) - The client key is used to authorize the device to send messages. If left blank, a key is auto-generated during client creation. Users may also provide their own key, and it can be edited later.
+- **Key** (optional) - The device key is used to authorize the device to send messages. If left blank, a key is auto-generated during device creation. Users may also provide their own key, and it can be edited later.
 - **Tags** (optional, for organization and filtering)
 
-Adding tags can help you quickly locate and manage clients in larger setups.
+Adding tags can help you quickly locate and manage devices in larger setups.
 
-![Create Client](../img/users-guide/group-client-create.png)
+![Create Device](../img/users-guide/group-client-create.png)
 
-A user can also create bulk clients by clicking on the `Upload` button. This will lead to a dialog box that takes in a _.CSV_ file with the client's details filled in correctly as seen in these [samples](https://github.com/absmach/magistrala-ui/tree/main/samples).
+A user can also create bulk devices by clicking on the `Upload` button. This will lead to a dialog box that takes in a _.CSV_ file with the device's details filled in correctly as seen in these [samples](https://github.com/absmach/magistrala-ui/tree/main/samples).
 
 The file should have the following fields in order:
 
@@ -143,37 +143,37 @@ The file should have the following fields in order:
 2. Metadata
 3. Tags
 
-![Create Clients](../img/users-guide/group-clients-create.png)
+![Create Devices](../img/users-guide/group-clients-create.png)
 
-### View a Client
+### View a Device
 
-Once created, a **group-client** can be viewed and updated in the unique Client's ID page.
-To open this page, click on the desired client in the **Clients** table.
+Once created, a **group-device** can be viewed and updated in the unique Device's ID page.
+To open this page, click on the desired device in the **Devices** table.
 
-From the Client Details page, you can:
+From the Device Details page, you can:
 
-- Update the client’s information
+- Update the device’s information
 - Copy its **ID** and **secret**
 - Manage its connections
-- Manage the Client's **Roles** as well as **Members**
-- View the Client's audit logs
+- Manage the Device's **Roles** as well as **Members**
+- View the Device's audit logs
 
-![View Client](../img/users-guide/group-client-view.png)
+![View Device](../img/users-guide/group-client-view.png)
 
-The **Connections** tab in the **group-client page** is where a User can connect a Client to a Channel.
+The **Connections** tab in the **group-device page** is where a User can connect a Device to a Channel.
 
 ## Create a Channel
 
-Channels act as **message conduits**, enabling communication between clients.
+Channels act as **message conduits**, enabling communication between devices.
 
-They serve as topics that multiple clients can **publish** to or **subscribe** from, allowing seamless device-to-device messaging.  
+They serve as topics that multiple devices can **publish** to or **subscribe** from, allowing seamless device-to-device messaging.  
 While subtopics are supported for more granular message routing, they are optional for basic interactions.
 
 Each channel has a **route**, which is a user-friendly alias for the channel’s ID.  
 The route makes it easier to reference or subscribe to the channel without needing the full UUID.  
 It is defined **only during creation** and cannot be changed later, so choose something short, clear, and descriptive.
 
-To create a channel, navigate to the fourth tab under the groups and click on `+ Create`. This will open a dialog box which will take in a unique Channel name. Much like the Clients, clicking on `Upload` will allow a user to upload a _.CSV_ file with multiple channels.
+To create a channel, navigate to the fourth tab under the groups and click on `+ Create`. This will open a dialog box which will take in a unique Channel name. Much like the Devices, clicking on `Upload` will allow a user to upload a _.CSV_ file with multiple channels.
 
 ![Create Group Channel](../img/users-guide/group-channel-create.png)
 
@@ -183,12 +183,12 @@ After the Channel is created, clicking on it while it is on the Channels table l
 
 ![View Group Channel](../img/users-guide/group-channel-view.png)
 
-Clients can be connected to channels in groups. This is done in the **Connections** tab. There are two connection types:
+Devices can be connected to channels in groups. This is done in the **Connections** tab. There are two connection types:
 
 - **Subscribe**
 - **Publish**
 
-![Connect Group Channel Clients](../img/users-guide/group-channel-connections.png)
+![Connect Group Channel Devices](../img/users-guide/group-channel-connections.png)
 
 ## Create a Rule
 
@@ -247,7 +247,7 @@ Your new rule will now appear in the Rules table, ready to process incoming mess
 
 ## Send a Message
 
-Once a Channel and Client are connected as well as Rule created, a user is able to send messages. Navigate to the `Messages` tab of the Group-Channel and click on `Send Messages`.
+Once a Channel and Device are connected as well as Rule created, a user is able to send messages. Navigate to the `Messages` tab of the Group-Channel and click on `Send Messages`.
 
 ![View Messages Page](../img/users-guide/group-messages-view.png)
 
@@ -261,13 +261,13 @@ Here are some examples:
 **Using HTTP**:
 
 ```bash
-curl -s -S -i --cacert docker/ssl/certs/ca.crt -X POST -H "Content-Type: application/senml+json" -H "Authorization: Client <client_secret>" https://localhost/http/m/<domain_id>/c/<channel_id> -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+curl -s -S -i --cacert docker/ssl/certs/ca.crt -X POST -H "Content-Type: application/senml+json" -H "Authorization: Client <device_secret>" https://localhost/http/m/<workspace_id>/c/<channel_id> -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 **Using MQTT**:
 
 ```bash
-mosquitto_pub -I <client_name> -u <client_id> -P <client_secret> -t m/<domain_id>/c/<channel_id> -h localhost -m '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+mosquitto_pub -I <device_name> -u <device_id> -P <device_secret> -t m/<workspace_id>/c/<channel_id> -h localhost -m '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 :::info

--- a/content/docs/user-guide/users-quick-start.mdx
+++ b/content/docs/user-guide/users-quick-start.mdx
@@ -69,7 +69,7 @@ After your email has been verified:
 
 > **Tip:** If you’ve already verified your email and are still on the verification page, click **Go to Workspaces Page** to continue.
 
-![Workspace Homepage](../img/users-guide/janedoe-domainshome.png)
+![Workspace Homepage](../img/users-guide/janedoe-workspaceshome.png)
 
 ## Log In
 
@@ -99,7 +99,7 @@ Click the `+ Create` button in the top-right corner to start. In addition to the
 
 > **The route is defined only at creation and cannot be changed later, so choose something short, clear, and descriptive.**
 
-![Workspace Create](../img/users-guide/jdoe-create-domain.png)
+![Workspace Create](../img/users-guide/jdoe-create-workspace.png)
 
 Once you create a workspace, you are given **admin** role over the workspace by default. You are able to perform all actions available over the workspace and all the entities provisioned inside the workspace. You can also assign or invite members to the workspace with various levels of permissions. Click on the respective card to log into a workspace of your choice.
 

--- a/content/docs/user-guide/white-labeling.mdx
+++ b/content/docs/user-guide/white-labeling.mdx
@@ -22,7 +22,7 @@ This guide walks through every option on the White Labeling page using a worked 
 
 Open the user menu in the top-right corner of the app (click your avatar) and select **White Labeling**.
 
-You can also reach it from **Platform Management → White Labeling**, alongside the **Domains** and **Users** admin tabs. Both paths lead to the same page, `/platform-management/white-labeling`; the user menu is just the faster route.
+You can also reach it from **Platform Management → White Labeling**, alongside the **Workspaces** and **Users** admin tabs. Both paths lead to the same page, `/platform-management/white-labeling`; the user menu is just the faster route.
 
 ![White Labeling page, Organization tab, before any changes](../img/white-labeling/white-labeling-page.png)
 
@@ -71,11 +71,11 @@ The **Media** tab handles every image asset: the main logo, the collapsed-sideba
 
 ### Logo
 
-This single **Logo** upload is shown both on the **login/auth page** and in the **expanded sidebar** (and in the top navigation bar shown before a domain is selected) — you don't upload separate images for each. Because it appears at different sizes in different places, you can set width/height independently for each surface:
+This single **Logo** upload is shown both on the **login/auth page** and in the **expanded sidebar** (and in the top navigation bar shown before a workspace is selected) — you don't upload separate images for each. Because it appears at different sizes in different places, you can set width/height independently for each surface:
 
 - **Auth page size** — the login screen
 - **Sidebar size** — the expanded sidebar
-- **Topbar size** — the top bar shown pre-domain-selection
+- **Topbar size** — the top bar shown pre-workspace-selection
 
 Use an SVG (or another format with a transparent background) sized roughly to its widest expected use — the width/height fields scale it down for the smaller placements, so a crisp source avoids blurring. Set **Alt text** too; it's read by screen readers everywhere the logo appears.
 
@@ -110,9 +110,9 @@ After saving, the White Labeling page itself reflects the new branding:
 
 ![White Labeling page after saving — sidebar, logo, and colors updated](../img/white-labeling/branding-applied-sidebar.png)
 
-So does the rest of the app — here's the domain home page:
+So does the rest of the app — here's the workspace home page:
 
-![Domain home page with Acme Enterprises branding applied](../img/white-labeling/branding-applied-home.png)
+![Workspace home page with Acme Enterprises branding applied](../img/white-labeling/branding-applied-home.png)
 
 Collapsing the sidebar swaps in the smaller **Collapsed sidebar logo**:
 


### PR DESCRIPTION
## Summary
Full audit/rewrite of the remaining user-guide areas not covered by the Workspaces/Devices/Gateways/Device-Types PRs: solution-packs, dashboards, rules-engine, messaging, message-views, alarms, reports, white-labeling, profile-management, pats, metadata, users-quick-start.

Highlights, all source-verified:
- **Documented a missing solution pack**: Cold Storage Monitoring existed in `magistrala-ui/backend/configs/solution-packs/` but had no docs page — written from the pack's actual `manifest.json`
- **Added a Bootstrap user-guide page** (previously dev-guide-only, despite `magistrala-ui` grouping Devices/Gateways/Device Types/Bootstrap together as one nav section) — verified Bootstrap is real and current (`cmd/atom-bootstrap`, UI at `/workspace/{id}/bootstraps` in both editions) by running `go build ./pkg/sdk/...` directly rather than trusting an earlier secondhand claim that it was broken
- **Fixed `pats.mdx`'s PAT scope tables** against the UI's actual scope config (`pat-scope-config.ts`), not just the backend permission schema, which disagreed with the UI in several places — added the genuinely-missing Bootstrap scope entity
- Confirmed all 17 documented dashboard widget types still match `magistrala-ui`'s current `ChartType`/`WidgetType` enum
- Fixed a real MDX build break (`<20%`, `<-26°C` parsed as invalid JSX tags) caught by actually running `pnpm run build`, not just lint
- Final terminology sweep: fixed stray "Client(s)" references in the solution-pack docs this branch owns, and one leftover "domain" reference in the new Cold Storage page

## Known gap, intentionally not closed here
Not a full re-verification of every workflow claim on every page (e.g. `reports.mdx`'s report-building steps) — terminology and obvious drift were checked everywhere, but deep accuracy audits were prioritized where evidence of staleness was found.

## Validation
`pnpm run build` passes (both editions) on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)